### PR TITLE
Adapte python3.7,delete catch StopIteration exception

### DIFF
--- a/ELMo/data.py
+++ b/ELMo/data.py
@@ -1,4 +1,5 @@
 # originally based on https://github.com/tensorflow/models/tree/master/lm_1b
+from __future__ import generators
 import glob
 import random
 
@@ -288,12 +289,7 @@ def _get_batch(generator, batch_size, num_steps, max_word_length):
 
             while cur_pos < num_steps:
                 if cur_stream[i] is None or len(cur_stream[i][0]) <= 1:
-                    try:
-                        cur_stream[i] = list(next(generator))
-                    except StopIteration:
-                        # No more data, exhaust current streams and quit
-                        no_more_data = True
-                        break
+                    cur_stream[i] = list(next(generator))
 
                 how_many = min(len(cur_stream[i][0]) - 1, num_steps - cur_pos)
                 next_pos = cur_pos + how_many


### PR DESCRIPTION
Adapte python3.7, fix a bug about stopIteration.
In python3.7, StopIteration changed handling inside generators. 
https://www.python.org/dev/peps/pep-0479/
Issue:http://newicafe.baidu.com:80/issue/DLTP-1660/show?from=page
