### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/model/ernie.py
+++ b/model/ernie.py
@@ -134,7 +134,7 @@ class ErnieModel(object):
         emb_out = pre_process_layer(
             emb_out, 'nd', self._prepostprocess_dropout, name='pre_encoder')
 
-        if self._dtype is "float16":
+        if self._dtype == "float16":
             emb_out = fluid.layers.cast(x=emb_out, dtype=self._dtype)
             input_mask = fluid.layers.cast(x=input_mask, dtype=self._dtype)
         self_attn_mask = fluid.layers.matmul(


### PR DESCRIPTION
Identity is not the same thing as equality in Python.

$ python
```
>>> self_dtype = "float"
>>> self_dtype += "16"
>>> self_dtype == "float16"
True
>>> self_dtype is "float16"
False
```