### PR TITLE
Undefined name: import sys for access to sys.exit() on line 61

### DIFF
--- a/utils/args.py
+++ b/utils/args.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import six
 import argparse
+import sys
 
 import paddle.fluid as fluid
 


### PR DESCRIPTION
The current code with probably raise __NameError__ at runtime instead of exiting as intended.