### PR TITLE
Fix TypeError on ernie_encoder.py

### DIFF
--- a/ernie_encoder.py
+++ b/ernie_encoder.py
@@ -170,10 +170,10 @@ def main(args):
     total_top_layer_emb = np.concatenate(total_top_layer_emb)
 
     with open(os.path.join(args.output_dir, "cls_emb.npy"),
-              "w") as cls_emb_file:
+              "wb") as cls_emb_file:
         np.save(cls_emb_file, total_cls_emb)
     with open(os.path.join(args.output_dir, "top_layer_emb.npy"),
-              "w") as top_layer_emb_file:
+              "wb") as top_layer_emb_file:
         np.save(top_layer_emb_file, total_top_layer_emb)
 
 


### PR DESCRIPTION
`ernie_encoder.py` Line 174, should use mode 'wb' to write binary files.
