### PR TITLE
Remove deprecated fluid.memory_optimize

### DIFF
--- a/train.py
+++ b/train.py
@@ -189,12 +189,6 @@ def train(args):
                 decr_ratio=args.decr_ratio)
 
 
-            fluid.memory_optimize(
-                input_program=train_program,
-                skip_opt_set=[
-                    next_sent_acc.name, mask_lm_loss.name, total_loss.name
-                ])
-
     test_prog = fluid.Program()
     with fluid.program_guard(test_prog, startup_prog):
         with fluid.unique_name.guard():


### PR DESCRIPTION
This PR removes the usages of empty interface `fluid.memory_optimize`, since it is deprecated in [PR18983](https://github.com/PaddlePaddle/Paddle/pull/18903).

