### PR TITLE
fix csv reader bug

### DIFF
--- a/reader/task_reader.py
+++ b/reader/task_reader.py
@@ -42,11 +42,7 @@ if six.PY3:
 def csv_reader(fd, delimiter='\t'):
     def gen():
         for i in fd:
-            slots = i.rstrip('\n').split(delimiter)
-            if len(slots) == 1:
-                yield slots,
-            else:
-                yield slots
+            yield i.rstrip('\n').split(delimiter)
     return gen()
 
 


### PR DESCRIPTION
str.split returns a **list** even though there exists only one column in text. No need to add extra dimension for that case, or the returned value will be a 2-dim list then raise errors when creating namedtuple after.