### PR TITLE
Undefined name: 'v' --> 'inf_sepc'

### DIFF
--- a/propeller/paddle/train/exporter.py
+++ b/propeller/paddle/train/exporter.py
@@ -83,7 +83,7 @@ class BestInferenceModelExporter(Exporter):
                 inf_sepc_dict = {'inference': inf_sepc_dict}
             for inf_sepc_name, inf_sepc in six.iteritems(inf_sepc_dict):
                 if not isinstance(inf_sepc, InferenceSpec):
-                    raise ValueError('unkonw inference spec type: %s' % v)
+                    raise ValueError('unknown inference spec type: %s' % inf_sepc)
 
                 save_dir = os.path.join(self._export_dir, inf_sepc_name)
                 log.debug('[Best Exporter]: save inference model: "%s" to %s' %


### PR DESCRIPTION
The current code would raise NameError instead of the expected ValueError.

flake8 testing of https://github.com/PaddlePaddle/ERNIE on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./propeller/paddle/train/exporter.py:86:73: F821 undefined name 'v'
                    raise ValueError('unkonw inference spec type: %s' % v)
                                                                        ^
```