### PR TITLE
do not use in-place reshaping; make reader work with jupyter i/o

### DIFF
--- a/ernie/model/transformer_encoder.py
+++ b/ernie/model/transformer_encoder.py
@@ -85,7 +85,7 @@ def multi_head_attention(queries,
         # The value 0 in shape attr means copying the corresponding dimension
         # size of the input as the output dimension size.
         reshaped = layers.reshape(
-            x=x, shape=[0, 0, n_head, hidden_size // n_head], inplace=True)
+            x=x, shape=[0, 0, n_head, hidden_size // n_head], inplace=False)
 
         # permuate the dimensions into:
         # [batch_size, n_head, max_sequence_len, hidden_size_per_head]
@@ -106,7 +106,7 @@ def multi_head_attention(queries,
         return layers.reshape(
             x=trans_x,
             shape=[0, 0, trans_x.shape[2] * trans_x.shape[3]],
-            inplace=True)
+            inplace=False)
 
     def scaled_dot_product_attention(q, k, v, attn_bias, d_key, dropout_rate):
         """

--- a/ernie/reader/task_reader.py
+++ b/ernie/reader/task_reader.py
@@ -33,7 +33,7 @@ from batching import pad_batch_data
 
 log = logging.getLogger(__name__)
 
-if six.PY3:
+if six.PY3 and hasattr(sys.stdout, 'buffer'):
     import io
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')


### PR DESCRIPTION
The problem with in-place operation is that it is not supported by tools such as ONNX. I could make it configurable but feel it is not important enough to add another config setting; however, I can update the PR if you feel so desired.

For change to the task reader, when running inside jupyter notebook, `sys.stdout.buffer` is not defined.