### PR TITLE
Fixed errors when only evaluating the fine-tuned sequence labeler.

### DIFF
--- a/ernie/finetune/sequence_label.py
+++ b/ernie/finetune/sequence_label.py
@@ -109,6 +109,11 @@ def create_model(args, pyreader_name, ernie_config, is_prediction=False):
 
 
 def calculate_f1(num_label, num_infer, num_correct):
+
+    num_infer = np.sum(num_infer)
+    num_label = np.sum(num_label)
+    num_correct = np.sum(num_correct)
+    
     if num_infer == 0:
         precision = 0.0
     else:

--- a/ernie/run_sequence_labeling.py
+++ b/ernie/run_sequence_labeling.py
@@ -289,10 +289,14 @@ def main(args):
 
     # final eval on dev set
     if nccl2_trainer_id ==0 and args.do_val:
+        if not args.do_train:
+            current_example, current_epoch = reader.get_train_progress()
         evaluate_wrapper(reader, exe, test_prog, test_pyreader, graph_vars,
                 current_epoch, 'final')
 
     if nccl2_trainer_id == 0 and args.do_test:
+        if not args.do_train:
+            current_example, current_epoch = reader.get_train_progress()
         predict_wrapper(reader, exe, test_prog, test_pyreader, graph_vars,
                 current_epoch, 'final')
 


### PR DESCRIPTION
Fixed errors when only evaluating the fine-tuned model for sequence labeling.

In calculate_f1, all three of the inputs are Numpy arrays, but it actually expects integers.

In main() of run_sequence_labeling.py, current_epoch was referenced before assignment if args.do_train is False.