### PR TITLE
NER 任务使用IO/plain模式的错误

### DIFF
--- a/ernie/finetune/sequence_label.py
+++ b/ernie/finetune/sequence_label.py
@@ -75,12 +75,12 @@ def create_model(args, pyreader_name, ernie_config, is_prediction=False):
     ret_infers = fluid.layers.reshape(x=infers, shape=[-1, 1])
     lod_labels = fluid.layers.sequence_unpad(labels, seq_lens)
     lod_infers = fluid.layers.sequence_unpad(infers, seq_lens)
-
+    _num_chunk_types = ((args.num_labels-1)//(len(args.chunk_scheme)-1)) if args.chunk_scheme != "plain" else 1
     (_, _, _, num_infer, num_label, num_correct) = fluid.layers.chunk_eval(
          input=lod_infers,
          label=lod_labels,
          chunk_scheme=args.chunk_scheme,
-         num_chunk_types=((args.num_labels-1)//(len(args.chunk_scheme)-1)))
+         num_chunk_types=_num_chunk_types)
 
     labels = fluid.layers.flatten(labels, axis=2)
     ce_loss, probs = fluid.layers.softmax_with_cross_entropy(

--- a/ernie/finetune_args.py
+++ b/ernie/finetune_args.py
@@ -95,7 +95,7 @@ data_g.add_arg("doc_stride",                int,   128,
                "When splitting up a long document into chunks, how much stride to take between chunks.")
 data_g.add_arg("n_best_size",               int,   20,
                "The total number of n-best predictions to generate in the nbest_predictions.json output file.")
-data_g.add_arg("chunk_scheme", type=str,  default="IOB", choices=["IO", "IOB", "IOE", "IOBES"], help="chunk scheme")
+data_g.add_arg("chunk_scheme", type=str,  default="IOB", choices=["plain", "IOB", "IOE", "IOBES"], help="chunk scheme")
 
 run_type_g = ArgumentGroup(parser, "run_type", "running type options.")
 run_type_g.add_arg("use_cuda",                     bool,   True,  "If set, use GPU for training.")


### PR DESCRIPTION
1. 使用的NER模式名称和paddlepaddle网站API不太一致，官网和paddle代码里是plain
2. ERNIE中使用IO导致出错，主要是导致num_chunk_type计算出错，修改了这个进行规避。
3. 也可以更改ernie/finetune/sequence_label.py#83行，如果是IO模式就把传入参数改为plain。