### PR TITLE
Fix import statement

### DIFF
--- a/demo/pretrain/make_pretrain_data.py
+++ b/demo/pretrain/make_pretrain_data.py
@@ -8,7 +8,7 @@ import logging
 from itertools import accumulate
 from functools import reduce, partial, wraps
 from propeller import log
-from propeller.paddle.data import feature_pb2, example_pb2
+from propeller.data import feature_pb2, example_pb2
 #jfrom data_util import RawtextColumn
 
 import io


### PR DESCRIPTION
Fixed the import statement at line 11 as suggested in Issue #740 
In `demo/pretrain/make_pretrain_data.py` the import is wrong
```
from propeller.paddle.data import feature_pb2, example_pb2
```

Change it to

```
from propeller.data import feature_pb2, example_pb2
```
Closes #740