### PR TITLE
Fix head_dim config

### DIFF
--- a/ernie/modeling.py
+++ b/ernie/modeling.py
@@ -557,7 +557,7 @@ class Ernie4_5_Attention(nn.Layer):
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.num_key_value_heads = config.num_key_value_heads
-        if config.head_dim is None:
+        if getattr(config, "head_dim", None) is None:
             self.head_dim = self.hidden_size // self.num_heads
         else:
             self.head_dim = config.head_dim
@@ -587,7 +587,7 @@ class Ernie4_5_Attention(nn.Layer):
             assert (
                 self.num_heads % self.num_key_value_heads == 0
             ), f"num_heads: {self.num_heads}, num_key_value_heads: {self.num_key_value_heads}"
-            if config.head_dim is None:
+            if getattr(config, "head_dim", None) is None:
                 kv_hidden_size = self.hidden_size // self.num_heads * self.num_key_value_heads
             else:
                 kv_hidden_size = self.head_dim * config.num_key_value_heads
@@ -607,7 +607,7 @@ class Ernie4_5_Attention(nn.Layer):
                 ColumnLN = RRColumnSequenceParallelLinear
                 column_ln_configs = {"use_rr": True}
 
-            if config.head_dim is None:
+            if getattr(config, "head_dim", None) is None:
                 qkv_hidden_size = self.hidden_size * 3 if not self.is_gqa else self.hidden_size + kv_hidden_size * 2
             else:
                 qkv_hidden_size = q_hidden_size + kv_hidden_size * 2
@@ -621,7 +621,7 @@ class Ernie4_5_Attention(nn.Layer):
             )
         else:
             LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else Linear
-            if config.head_dim is None:
+            if getattr(config, "head_dim", None) is None:
                 qkv_hidden_size = self.hidden_size * 3 if not self.is_gqa else self.hidden_size + kv_hidden_size * 2
             else:
                 qkv_hidden_size = q_hidden_size + kv_hidden_size * 2
@@ -642,7 +642,7 @@ class Ernie4_5_Attention(nn.Layer):
                 row_ln_configs = {"use_rr": True}
 
             self.o_proj = RowLN(
-                self.hidden_size if config.head_dim is None else q_hidden_size,
+                self.hidden_size if getattr(config, "head_dim", None) is None else q_hidden_size,
                 self.hidden_size,
                 has_bias=config.use_bias,
                 input_is_parallel=True,
@@ -652,7 +652,7 @@ class Ernie4_5_Attention(nn.Layer):
         else:
             LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else Linear
             self.o_proj = LinearFN(
-                self.hidden_size if config.head_dim is None else q_hidden_size,
+                self.hidden_size if getattr(config, "head_dim", None) is None else q_hidden_size,
                 self.hidden_size,
                 bias_attr=config.use_bias,
             )

--- a/ernie/modeling_moe.py
+++ b/ernie/modeling_moe.py
@@ -876,7 +876,7 @@ class Ernie4_5_PretrainedModel(PretrainedModel):
                     num_key_value_heads=config.num_key_value_heads,
                     head_dim=(
                         config.hidden_size // config.num_attention_heads
-                        if config.head_dim is None
+                        if getattr(config, "head_dim", None) is None:
                         else config.head_dim
                     ),
                     is_quant=False,
@@ -889,7 +889,7 @@ class Ernie4_5_PretrainedModel(PretrainedModel):
                     num_key_value_heads=config.num_key_value_heads,
                     head_dim=(
                         config.hidden_size // config.num_attention_heads
-                        if config.head_dim is None
+                        if getattr(config, "head_dim", None) is None:
                         else config.head_dim
                     ),
                     is_quant=False,

--- a/erniekit/train/dpo/workflow.py
+++ b/erniekit/train/dpo/workflow.py
@@ -282,6 +282,12 @@ def run_dpo(
         else:
             ref_model = None
     model.config.dpo_config = None
+
+    if model.config.head_dim is None:
+        del model.config.head_dim
+    if ref_model is not None and ref_model.config.head_dim is None:
+        del ref_model.config.head_dim
+
     if model_args.lora:
         logger.info("Start to wrap model with LoRA config ...")
         if model_args.lora_path is None:

--- a/erniekit/train/sft/workflow.py
+++ b/erniekit/train/sft/workflow.py
@@ -288,6 +288,9 @@ def run_sft(
     else:
         model = model_class.from_config(model_config, dtype=dtype)
 
+    if model.config.head_dim is None:
+        del model.config.head_dim
+
     paddle.device.cuda.empty_cache()
     logger.info("Loading model successfully !")
     logger.debug(f"Model config: {model.config}")

--- a/examples/post-training/dpo/dpo_train.py
+++ b/examples/post-training/dpo/dpo_train.py
@@ -268,6 +268,12 @@ def main():
         else:
             ref_model = None
     model.config.dpo_config = None
+
+    if model.config.head_dim is None:
+        del model.config.head_dim
+    if ref_model is not None and ref_model.config.head_dim is None:
+        del ref_model.config.head_dim
+
     if dpo_config.lora:
         logger.info("Start to wrap model with LoRA config ...")
         if model_args.lora_path is None:

--- a/examples/post-training/sft/train.py
+++ b/examples/post-training/sft/train.py
@@ -589,6 +589,9 @@ def main():
     else:
         model = model_class.from_config(model_config, dtype=dtype)
 
+    if model.config.head_dim is None:
+        del model.config.head_dim
+
     paddle.device.cuda.empty_cache()
     logger.info("Loading model successfully !")
     logger.debug(f"Model config: {model.config}")


### PR DESCRIPTION
由于非0.3B模型在保存config时将head_dim保存为null，导致fastdeploy部署时会报错，进行修复。