### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements/gpu/requirements.txt
+++ b/requirements/gpu/requirements.txt
@@ -1,5 +1,5 @@
 paddleformers
-setuptools==50.3.2
+setuptools==79.0.1
 decord
 moviepy
 GPUtil


### PR DESCRIPTION
Python 3.12 版本已经完全移除了 distutils 这个库，安装的这个包（ERNIE）在构建时仍然依赖它。环境中旧版的 setuptools(50版本)尝试去 import distutils.core，因此直接导致 ModuleNotFoundError 错误。 错误如下：
![image](https://github.com/user-attachments/assets/e8526c24-fb2d-428e-8dba-6de186b2459b)

由于推理依赖FastDeploy ,要求setuptools版本<8.0.1，会自动降级为79.0.1

故 经验证setuptools的版本为79.0.1更为合适
![image](https://github.com/user-attachments/assets/b7e54392-0b6f-4b84-9415-34d1076d202a)
