### PR TITLE
fix(webui eval dataset_type)

### DIFF
--- a/erniekit/webui/common.py
+++ b/erniekit/webui/common.py
@@ -750,8 +750,6 @@ def update_dataset_paths(config_dict, manager, is_preview=False):
             eval_config["eval_customize_dataset_prob"], eval_config["eval_existed_dataset_prob"]
         )
 
-        eval_config["eval_customize_dataset_type"] = None
-
         eval_config["eval_dataset_type"] = merge_values(
             eval_config["eval_customize_dataset_type"], eval_config["eval_existed_dataset_type"]
         )


### PR DESCRIPTION
修复 webui在eval中写入yaml执行文件的时候，dataset_type没有成功写入的bug