### PR TITLE
Fix the ‘use_quant_before_a2a’ optimization flag.

### DIFF
--- a/examples/pre-training/models/moe/moe_layer.py
+++ b/examples/pre-training/models/moe/moe_layer.py
@@ -96,12 +96,11 @@ class Fp8MoeGateDispatchAndQuant(paddle.autograd.PyLayer):
             )
         assert out_fp8.shape[0] == scale.shape[0]
 
+        out_fp8.stop_gradient = False
         combine_weights.stop_gradient = False
         scatter_index.stop_gradient = True
         expert_offset.stop_gradient = True
         expert_id.stop_gradient = True
-
-        out_fp8.stop_gradient = True
         scale.stop_gradient = True
 
         ctx.k = k


### PR DESCRIPTION
Remove the fake bf16 output when use_quant_before_a2a is enabled, to improve code clarity and conciseness.

Related PR:
https://github.com/PaddlePaddle/Paddle/pull/73763
https://github.com/PaddlePaddle/ERNIE/pull/971