### PR TITLE
Fix erniekit bugs in resuming checkpoint

### DIFF
--- a/erniekit/train/vl_sft/trainer.py
+++ b/erniekit/train/vl_sft/trainer.py
@@ -29,7 +29,7 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 import paddle.distributed.fleet.meta_optimizers.dygraph_optimizer
-import tqdm
+from tqdm import tqdm
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
     HybridParallelOptimizer,
 )
@@ -548,7 +548,6 @@ class SFTTrainer(PretrainingTrainer):
                         steps_trained_progress_bar.update(1)
                     if steps_trained_in_current_epoch == 0:
                         self._load_rng_state(resume_from_checkpoint)
-                    self.timers and self.timers("read-data").start()
                     continue
                 elif steps_trained_progress_bar is not None:
                     steps_trained_progress_bar.close()


### PR DESCRIPTION
Make the processing logic of consumed data consistent within the PP group. They will enter a "continue" loop to skip the consumed data regardless of pp_need_data. Remove the timer for the skipping process to avoid the conflict. More details in https://github.com/PaddlePaddle/ERNIE/pull/1165