### PR TITLE
add loss_subbatch_seqlen in configuration.py

### DIFF
--- a/ernie/configuration.py
+++ b/ernie/configuration.py
@@ -110,6 +110,7 @@ class Ernie4_5_Config(PretrainedConfig):
         use_fused_head_and_loss_fn=False,
         token_balance_loss=False,
         token_balance_seqlen=False,  # calculated based on batchsize and seqlen
+        loss_subbatch_seqlen=32768,
         cachekv_quant: bool = False,
         pp_seg_method="layer:Ernie4_5_DecoderLayer|EmptyLayer",
         **kwargs,
@@ -159,6 +160,7 @@ class Ernie4_5_Config(PretrainedConfig):
             use_fused_head_and_loss_fn (bool): Whether to use fused head and loss function
             token_balance_loss (bool): Whether to balance loss by token count
             token_balance_seqlen (bool): Whether to balance sequence lengths
+            loss_subbatch_seqlen (int): Sub-batch size for loss computation
             cachekv_quant (bool): Whether to quantize key-value cache
             pp_seg_method (str): Method for pipeline parallel segmentation
             **kwargs: Additional keyword arguments passed to parent class
@@ -241,6 +243,7 @@ class Ernie4_5_Config(PretrainedConfig):
         self.use_fused_head_and_loss_fn = use_fused_head_and_loss_fn
         self.token_balance_loss = token_balance_loss
         self.token_balance_seqlen = token_balance_seqlen
+        self.loss_subbatch_seqlen = loss_subbatch_seqlen
         self.cachekv_quant = cachekv_quant
         self.pp_seg_method = pp_seg_method
 
@@ -257,6 +260,7 @@ class Ernie4_5_Config(PretrainedConfig):
                 "use_sparse_flash_attn",
                 "use_var_len_flash_attn",
                 "use_sparse_head_and_loss_fn",
+                "loss_subbatch_seqlen",
                 "micro_batch_size",
                 "fuse_softmax_mask",
                 "cachekv_quant",


### PR DESCRIPTION
修复ERNIE跟paddleformers develop分支的兼容性问题。由于paddleformers develop分支代码将loss_subbatch_seqlen 修改成了-1，影响了ERNIE代码中loss计算 （https://github.com/PaddlePaddle/ERNIE/blob/2b93a9f6a83af82ae59f3136da07a534e2a6f66b/ernie/modeling.py#L1570）