### PR TITLE
[AutoParallel] Resue auto parllel functions

### DIFF
--- a/examples/auto_parallel/models/modeling_auto.py
+++ b/examples/auto_parallel/models/modeling_auto.py
@@ -21,7 +21,6 @@ import contextlib
 
 from copy import deepcopy
 from dataclasses import dataclass
-import numpy as np
 import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
@@ -29,7 +28,6 @@ from paddle.distributed import fleet
 from paddle import nn
 from paddle.distributed.fleet.utils import recompute
 from paddle.distributed.fleet.layers.mpu.random import get_rng_state_tracker
-from paddle.distributed import in_auto_parallel_align_mode
 
 from models.top2_gate_auto import TopKGateFusedAuto
 
@@ -39,7 +37,7 @@ from paddleformers.transformers.model_outputs import (
 )
 from paddleformers.transformers.model_outputs import CausalLMOutputWithCrossAttentions
 
-from paddleformers.transformers.model_utils import PretrainedModel, register_base_model
+from paddleformers.transformers.model_utils import PretrainedModel
 
 from models.moe_layer_auto import (
     MOELayerAuto,
@@ -51,7 +49,7 @@ from utils_auto.training_utils import get_mesh
 
 from paddle.nn.functional.flash_attention import flash_attention
 from paddle.incubate.nn.functional import fused_rotary_position_embedding as fused_rope
-from paddle.incubate.nn.functional import swiglu as fused_swiglu
+from paddle.incubate.nn.functional import swiglu
 
 
 @dataclass
@@ -87,18 +85,6 @@ class FusedDropoutImpl(nn.Layer):
         output = x + y
 
         return output
-
-
-def get_triangle_upper_mask(x, mask=None):
-    if mask is not None:
-        return mask
-    shape = x.shape
-    shape[1] = 1
-    mask = paddle.full(shape, -np.inf, dtype=x.dtype)
-    mask.stop_gradient = True
-    mask = paddle.triu(mask, diagonal=1)
-    mask.stop_gradient = True
-    return mask
 
 
 def calc_lm_head_logits(
@@ -203,7 +189,7 @@ def scaled_dot_product_attention(
             )
 
         if attention_mask is None:
-            attention_mask = get_triangle_upper_mask(attn_weights)
+            attention_mask = F.get_triangle_upper_mask(attn_weights)
 
         attention_mask = attention_mask.reshape([bsz, 1, q_len, kv_seq_len])
         if attention_mask.shape != [bsz, 1, q_len, kv_seq_len]:
@@ -220,15 +206,11 @@ def scaled_dot_product_attention(
                 ),
             )
 
-            if paddle.in_dynamic_mode():
-                with paddle.amp.auto_cast(False):
-                    attn_weights = F.softmax(
-                        attn_weights, axis=-1, dtype="float32"
-                    ).astype(query_states.dtype)
-            else:
+            with paddle.amp.auto_cast(False):
                 attn_weights = F.softmax(attn_weights, axis=-1, dtype="float32").astype(
                     query_states.dtype
                 )
+
         else:
             attn_weights = attn_weights.cast(paddle.float32)
             attention_mask = attention_mask.cast(paddle.float32)
@@ -384,13 +366,7 @@ class RMSNorm(nn.Layer):
             return paddle.incubate.nn.functional.fused_rms_norm_ext(
                 hidden_states, self.weight, self.variance_epsilon
             )[0]
-        if paddle.in_dynamic_mode():
-            with paddle.amp.auto_cast(False):
-                variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
-                hidden_states = (
-                    paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
-                )
-        else:
+        with paddle.amp.auto_cast(False):
             variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
             hidden_states = (
                 paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
@@ -605,12 +581,10 @@ class ErnieMLP(nn.Layer):
                 )
 
         self.fuse_swiglu = config.fuse_swiglu
-        if self.fuse_swiglu:
-            assert fused_swiglu is not None, "fused_swiglu operator is not found."
 
     def forward(self, x):
         if self.fuse_swiglu:
-            x = fused_swiglu(self.gate_proj(x), self.up_proj(x))
+            x = swiglu(self.gate_proj(x), self.up_proj(x))
         else:
             x = F.silu(self.gate_proj(x)) * self.up_proj(x)
 
@@ -633,8 +607,6 @@ class ErnieAttentionAuto(nn.Layer):
             config.num_key_value_heads is not None
             and config.num_key_value_heads != self.num_heads
         )
-        if config.fuse_rope:
-            assert fused_rope is not None, "fused_rope is not supported"
         self.fuse_rope = config.fuse_rope
 
         if self.is_gqa:
@@ -683,46 +655,42 @@ class ErnieAttentionAuto(nn.Layer):
 
         self.config = config
 
-        if (
-            self.config.tensor_parallel_degree > 1
-            or self.config.pipeline_parallel_degree > 1
-        ):
-            self.q_proj.weight = dist.shard_tensor(
-                self.q_proj.weight,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(1)],
-            )
-            self.k_proj.weight = dist.shard_tensor(
-                self.k_proj.weight,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(1)],
-            )
-            self.v_proj.weight = dist.shard_tensor(
-                self.v_proj.weight,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(1)],
-            )
-            if config.use_bias:
-                self.q_proj.bias = dist.shard_tensor(
-                    self.q_proj.bias,
-                    get_mesh(self.ipp),
-                    [dist.Replicate(), dist.Shard(0)],
-                )
-                self.k_proj.bias = dist.shard_tensor(
-                    self.k_proj.bias,
-                    get_mesh(self.ipp),
-                    [dist.Replicate(), dist.Shard(0)],
-                )
-                self.v_proj.bias = dist.shard_tensor(
-                    self.v_proj.bias,
-                    get_mesh(self.ipp),
-                    [dist.Replicate(), dist.Shard(0)],
-                )
-            self.o_proj.weight = dist.shard_tensor(
-                self.o_proj.weight,
+        self.q_proj.weight = dist.shard_tensor(
+            self.q_proj.weight,
+            get_mesh(self.ipp),
+            [dist.Replicate(), dist.Shard(1)],
+        )
+        self.k_proj.weight = dist.shard_tensor(
+            self.k_proj.weight,
+            get_mesh(self.ipp),
+            [dist.Replicate(), dist.Shard(1)],
+        )
+        self.v_proj.weight = dist.shard_tensor(
+            self.v_proj.weight,
+            get_mesh(self.ipp),
+            [dist.Replicate(), dist.Shard(1)],
+        )
+        if config.use_bias:
+            self.q_proj.bias = dist.shard_tensor(
+                self.q_proj.bias,
                 get_mesh(self.ipp),
                 [dist.Replicate(), dist.Shard(0)],
             )
+            self.k_proj.bias = dist.shard_tensor(
+                self.k_proj.bias,
+                get_mesh(self.ipp),
+                [dist.Replicate(), dist.Shard(0)],
+            )
+            self.v_proj.bias = dist.shard_tensor(
+                self.v_proj.bias,
+                get_mesh(self.ipp),
+                [dist.Replicate(), dist.Shard(0)],
+            )
+        self.o_proj.weight = dist.shard_tensor(
+            self.o_proj.weight,
+            get_mesh(self.ipp),
+            [dist.Replicate(), dist.Shard(0)],
+        )
 
     def forward(
         self,
@@ -907,8 +875,6 @@ class ErnieMoeMLP(ErnieMLP):
         super().__init__(config, ipp, do_shard_tensor=not disable_ffn_model_parallel)
         self.moe_dropout_prob = config.moe_dropout_prob
         self.fuse_swiglu = config.fuse_swiglu
-        if self.fuse_swiglu:
-            assert fused_swiglu is not None, "fused_swiglu operator is not found."
 
     def redistribute_expert(self, mesh, placements):
         """
@@ -932,7 +898,7 @@ class ErnieMoeMLP(ErnieMLP):
 
     def forward(self, x):
         if self.fuse_swiglu:
-            x = fused_swiglu(self.gate_proj(x), self.up_proj(x))
+            x = swiglu(self.gate_proj(x), self.up_proj(x))
         else:
             x = F.silu(self.gate_proj(x)) * self.up_proj(x)
         if self.moe_dropout_prob > 0:
@@ -983,8 +949,6 @@ class ErnieMoeMLPFused(nn.Layer):
             self.num_local_experts, config.intermediate_size, config.hidden_size
         )
         self.fuse_swiglu = config.fuse_swiglu
-        if self.fuse_swiglu:
-            assert fused_swiglu is not None, "fused_swiglu operator is not found."
 
     def __len__(self):
         return self.num_local_experts
@@ -994,7 +958,7 @@ class ErnieMoeMLPFused(nn.Layer):
 
     def forward(self, x):
         if self.fuse_swiglu:
-            x = fused_swiglu(self.up_gate_proj(x))
+            x = swiglu(self.up_gate_proj(x))
         else:
             gate, x = self.up_gate_proj(x).chunk(2, axis=-1)
             x = F.silu(gate) * x
@@ -1338,7 +1302,6 @@ class ErniePretrainedModelAuto(PretrainedModel):
                 )
 
 
-@register_base_model
 class ErnieModelAuto(ErniePretrainedModelAuto):
     """
     Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer is a [`ErnieDecoderLayerAuto`]
@@ -1357,16 +1320,11 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
                 self.vocab_size,
                 self.hidden_size,
             )
-            if (
-                self.config.tensor_parallel_degree > 1
-                or self.config.pipeline_parallel_degree > 1
-            ):
-                if not in_auto_parallel_align_mode():
-                    self.embed_tokens.weight = dist.shard_tensor(
-                        self.embed_tokens.weight,
-                        get_mesh(pp_idx=0),
-                        [dist.Replicate(), dist.Shard(1)],
-                    )
+            self.embed_tokens.weight = dist.shard_tensor(
+                self.embed_tokens.weight,
+                get_mesh(pp_idx=0),
+                [dist.Replicate(), dist.Shard(1)],
+            )
         if config.pipeline_parallel_degree <= 1:
             self.layers = nn.LayerList()
             for idx in range(
@@ -1529,9 +1487,7 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
                 [dist.Replicate() for _ in range(len(global_mesh._shape))],
             )
 
-        hidden_states = inputs_embeds
-        if self.config.tensor_parallel_degree > 1:
-            hidden_states = dist.reshard(hidden_states, get_mesh(0), self.placements)
+        hidden_states = dist.reshard(inputs_embeds, get_mesh(0), self.placements)
 
         return hidden_states, attention_mask, position_ids
 
@@ -1704,7 +1660,7 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
             loss, loss_sum = res
         else:
             loss, loss_sum = res, None
-        if router_loss is not None and not in_auto_parallel_align_mode():
+        if router_loss is not None:
             loss = loss + router_loss - router_loss.detach()
         if not self.return_tuple:
             return loss

--- a/examples/auto_parallel/models/moe_layer_auto.py
+++ b/examples/auto_parallel/models/moe_layer_auto.py
@@ -30,6 +30,7 @@ from paddle import Tensor
 from paddle.incubate.nn.functional import moe_combine, moe_gate_dispatch
 
 from paddleformers.trainer.plugins.timer import get_timers
+from paddleformers.transformers.moe_layer_auto import dispatching, combining
 from models.top2_gate_auto import TopKGateFused, TopKGateFusedAuto
 from utils_auto.training_utils import get_flatten_mesh, get_mesh, _reshard
 
@@ -95,120 +96,6 @@ def profile(name):
         get_timers()(name).stop()
 
 
-def dispatching(x, dispatch_mask, scatter_index, num_experts, capacity):
-    output = None
-    orig_dtype = x.dtype
-    scatter_index = scatter_index.unbind(1)
-    dispatch_mask = dispatch_mask.unbind(1)
-    for i_scatter_index, i_dispatch_mask in zip(scatter_index, dispatch_mask):
-        init_output = paddle.zeros(
-            [num_experts * capacity, x.shape[-1]], dtype="float32"
-        )
-        updates = x * i_dispatch_mask.unsqueeze(-1).cast(x.dtype)
-
-        cur_out = paddle.scatter(
-            init_output,
-            i_scatter_index,
-            updates,
-            overwrite=False,
-        )
-        output = cur_out if output is None else cur_out + output
-        output = output.cast(orig_dtype) if output.dtype != orig_dtype else output
-    return output
-
-
-def combining(x, combine_weights, scatter_index):
-    dim = x.shape[-1]
-    scatter_index = scatter_index.reshape([-1])
-    num_k = combine_weights.shape[-1]
-    combine_weights = combine_weights.unsqueeze(1)
-    x = paddle.gather(x, scatter_index).reshape([-1, num_k, dim])
-    return paddle.matmul(combine_weights, x).squeeze(1)
-
-
-class MOELayer(nn.Layer):
-    def __init__(
-        self,
-        gate: nn.Layer,
-        experts: List[nn.Layer],
-        layer_idx: int,
-        shared_experts: Optional[List[nn.Layer]] = None,
-        group: Group = None,
-        recompute: bool = False,
-        k: int = 2,
-        all_to_all_dropout: float = 0,
-        group_experts: bool = False,
-        moe_statics=None,
-    ):
-
-        self.use_correction_bias = moe_statics is not None
-        self.moe_statics = moe_statics
-        if self.use_correction_bias:
-            logger.info(
-                f"using correction bias, aux-coef:{self.gate.config.moe_aux_loss_lambda}"
-            )
-            assert self.gate.config.moe_use_aux_free
-
-        self.is_mp_moe = (
-            hasattr(fleet.fleet, "_hcg")
-            and group is fleet.get_hybrid_communicate_group().get_model_parallel_group()
-        )
-        self.is_ep_moe = (
-            hasattr(fleet.fleet, "_hcg")
-            and hasattr(
-                fleet.get_hybrid_communicate_group(),
-                "get_moe_sharding_parallel_world_size",
-            )
-            and fleet.get_hybrid_communicate_group().get_moe_sharding_parallel_world_size()
-            > 0
-        )
-        is_dummy_moe = dist.get_world_size(group) == 1
-
-        for p in experts.parameters():
-            p.expert = not (self.is_mp_moe or is_dummy_moe)
-            p.no_sync = not (self.is_mp_moe or is_dummy_moe)
-            logger.info(f"expert no-sync={p.no_sync}-{p.name}")
-            if self.is_mp_moe or self.is_ep_moe:
-                p.is_distributed = True
-
-        expert_color = None
-        if self.is_ep_moe:
-            moe_grad_group = (
-                fleet.get_hybrid_communicate_group().get_moe_sharding_parallel_group()
-            )
-            expert_color = {"color": "moe_expert", "group": moe_grad_group}
-        elif (
-            self.config.offline_quant_expert_weight
-            and self.config.clear_origin_weight_when_offline_quant
-        ):
-            expert_color = {"color": "moe_expert"}
-
-        if expert_color is not None:
-            for p in self.experts.parameters():
-                setattr(p, "color", expert_color)
-
-        self.world_size = dist.get_world_size(self.group)
-        self.rank = dist.get_rank(self.group)
-        if self.world_size < 1:
-            self.world_size = 1
-        if self.rank < 0:
-            self.rank = 0
-
-        self.num_local_experts = len(self.experts)
-        self.dispatch_by_task = (
-            hasattr(self.gate, "dispatch_by_task") and self.gate.dispatch_by_task
-        )
-
-        if self.dispatch_by_task:
-            assert 0, "no supported, checkout earylier code"
-            assert self.num_local_experts == 1
-
-        self.input_preprocess = self.output_postprocess = None
-        self.group_experts = group_experts
-        self.config = self.gate.config
-        self.zero = paddle.to_tensor(0, dtype=paddle.float32)
-
-
 def combining_fused_auto(x, combine_weights, scatter_index, hard_gate=False):
     """
     Args:
@@ -228,8 +115,7 @@ def combining_fused_auto(x, combine_weights, scatter_index, hard_gate=False):
     return ret
 
 
-class MOELayerAuto(MOELayer):
-
+class MOELayerAuto(nn.Layer):
     def __init__(
         self,
         gate: nn.Layer,
@@ -245,7 +131,7 @@ class MOELayerAuto(MOELayer):
         config=None,
         ipp=0,
     ):
-        nn.Layer.__init__(self)
+        super().__init__(self)
         self.config = config
         self.gate = gate
         self.layer_idx = layer_idx
@@ -638,8 +524,8 @@ class MOELayerAuto(MOELayer):
             else:
                 dispatched_input = dispatching(
                     input,
-                    dispatch_mask,
-                    scatter_index,
+                    dispatch_mask.unbind(1),
+                    scatter_index.unbind(1),
                     num_experts=self.config.moe_num_experts,
                     capacity=capacity,
                 )
@@ -689,6 +575,10 @@ class MOELayerAuto(MOELayer):
                     )
             use_fuse = isinstance(self.gate, (TopKGateFusedAuto))
             combine_fn = combining_fused_auto if use_fuse else combining
+            combine_weights = (
+                combine_weights if use_fuse else combine_weights.unsqueeze(1)
+            )
+
             combined_output = combine_fn(expert_output, combine_weights, scatter_index)
 
             if self.output_postprocess is not None:


### PR DESCRIPTION
1. 移除 in_auto_parallel_align_mode
2. @register_base_model 用于添加 base_model_class 标记基础父类，在自动并行中不起作用，故删除
3. 直接 import swiglu，并不使用 as fused_swiglu
4. get_triangle_upper_mask 复用 paddle 中实现
5. 移除 not in_dynamic_mode 分支
6. 去除无用的 assert，例如从paddle 中导入 fused_rope ，移除代码中的 assert fused_rope is not None
7. 在 tp_degree>1 or pp_degree > 1 情况下进行的reshard，可以直接 reshard，无需判断
8. dispatching和combining可以用 paddleformers 中的实现，但是类型需要额外处理

- dispatching 中需要参数 dispatch_mask 和 scatter_index 提前进行 unbind(1) 处理
对比paddleformers实现（图左）和erniekit原有实现（图右）
<img width="1576" height="390" alt="757007f141f2bd81f9378579e27b406b" src="https://github.com/user-attachments/assets/da3fe7a6-9e10-42da-9072-67270b76ebd5" />

- combining 中需要 combine_weights 提前进行 unsqueeze(1) 处理
对比paddleformers实现（图左）和erniekit原有实现（图右）
<img width="1506" height="296" alt="37b2f20372282e89c437746c75ae9b19" src="https://github.com/user-attachments/assets/f6a01611-1f50-4b73-ab5a-261280bd94a9" />


10. MOELayerAuto 直接继承 Layer，去除 MOELayer