### PR TITLE
[AutoParallel] Restore use_moe config

### DIFF
--- a/examples/auto_parallel/models/configuration_auto.py
+++ b/examples/auto_parallel/models/configuration_auto.py
@@ -663,6 +663,14 @@ class ErnieMoEConfig(ErnieConfig):
             and len(self.moe_num_experts) > 1
         )
 
+    @property
+    def use_moe(self) -> bool:
+        return (
+            sum(self.moe_num_experts) > 0
+            if self.multimodel_experts
+            else self.moe_num_experts > 0
+        )
+
     def __setattr__(self, name: str, value):
         super().__setattr__(name, value)
         if getattr(self, "use_recompute", False):

--- a/examples/auto_parallel/models/modeling_auto.py
+++ b/examples/auto_parallel/models/modeling_auto.py
@@ -1099,6 +1099,7 @@ class ErnieDecoderLayerAuto(nn.Layer):
             k=self.config.moe_k,
             all_to_all_dropout=self.config.moe_all_to_all_dropout,
             group_experts=self.config.moe_group_experts,
+            moe_statics=moe_statics,
             config=self.config,
             ipp=self.ipp,
         )

--- a/examples/auto_parallel/models/moe_layer_auto.py
+++ b/examples/auto_parallel/models/moe_layer_auto.py
@@ -131,7 +131,7 @@ class MOELayerAuto(nn.Layer):
         config=None,
         ipp=0,
     ):
-        super().__init__(self)
+        super().__init__()
         self.config = config
         self.gate = gate
         self.layer_idx = layer_idx

--- a/examples/auto_parallel/pretrain_auto.py
+++ b/examples/auto_parallel/pretrain_auto.py
@@ -22,6 +22,7 @@ import numpy as np
 import paddle
 from omegaconf import ListConfig, DictConfig
 from paddle.distributed.fleet import fleet
+from paddle.distributed.auto_parallel import get_mesh
 from paddleformers.data import Stack
 from paddleformers.data.causal_dataset import (
     build_train_valid_test_datasets,
@@ -464,10 +465,10 @@ def set_moe_config(config):
             config.disable_ffn_model_parallel = True
 
         config.moe_world_size = 1
-        if config.moe_group in fleet.auto.get_mesh().dim_names:
+        if config.moe_group in get_mesh().dim_names:
             config.moe_world_size = max(
                 config.moe_world_size,
-                fleet.auto.get_mesh().get_dim_size(config.moe_group),
+                get_mesh().get_dim_size(config.moe_group),
             )
 
 


### PR DESCRIPTION
在 https://github.com/PaddlePaddle/ERNIE/pull/1208 中误删 use_moe  和 moe_statics，该 PR 对其进行恢复，并修复一些 import 和初始化 问题