### PR TITLE
[AutoParallel] using single modeling_auto.py & intermediate api to achieve auto parallel

### DIFF
--- a/examples/auto_parallel/models/modeling_auto.py
+++ b/examples/auto_parallel/models/modeling_auto.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
-from paddle.distributed import fleet
 from paddle import nn
 from paddle.distributed.fleet.utils import recompute
 from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
@@ -32,7 +31,9 @@ from paddle.distributed.fleet.layers.mpu.random import get_rng_state_tracker
 
 from models.top2_gate_auto import TopKGateFusedAuto
 
-
+from paddle.distributed.auto_parallel.intermediate.tensor_parallel import (
+    PrepareLayerInput,
+)
 from paddleformers.transformers.model_outputs import (
     BaseModelOutputWithPastAndCrossAttentions as _BaseModelOutput,
 )
@@ -81,27 +82,27 @@ def calc_lm_head_logits(
     tensor_parallel_output=None,
 ):
     """the core function to calc lm head"""
-    if config.sequence_parallel:
-        hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
-        dp_rank = hcg.get_data_parallel_rank()
-        sharding_rank = hcg.get_sharding_parallel_rank()
-        if dp_rank <= 1 and sharding_rank <= 1:
-            hidden_states = dist.reshard(
-                hidden_states,
-                get_mesh(-1),
-                [dist.Replicate(), dist.Replicate()],
-            )
-        else:
-            hidden_states = dist.reshard(
-                hidden_states,
-                get_mesh(-1),
-                [dist.Shard(1), dist.Replicate()],
-            )
-        # [S, B, H] to [B, S, H]
-        hidden_states = paddle.transpose(hidden_states, [1, 0, 2])
-        hidden_states = hidden_states.reshape(
-            [-1, config.seqlen, hidden_states.shape[-1]]
-        )
+    # if config.sequence_parallel:
+    #     hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
+    #     dp_rank = hcg.get_data_parallel_rank()
+    #     sharding_rank = hcg.get_sharding_parallel_rank()
+    #     if dp_rank <= 1 and sharding_rank <= 1:
+    #         hidden_states = dist.reshard(
+    #             hidden_states,
+    #             get_mesh(-1),
+    #             [dist.Replicate(), dist.Replicate()],
+    #         )
+    #     else:
+    #         hidden_states = dist.reshard(
+    #             hidden_states,
+    #             get_mesh(-1),
+    #             [dist.Shard(1), dist.Replicate()],
+    #         )
+    #     # [S, B, H] to [B, S, H]
+    #     hidden_states = paddle.transpose(hidden_states, [1, 0, 2])
+    #     hidden_states = hidden_states.reshape(
+    #         [-1, config.seqlen, hidden_states.shape[-1]]
+    #     )
     if tensor_parallel_output is None:
         tensor_parallel_output = config.tensor_parallel_output
 
@@ -368,13 +369,13 @@ class LayerNorm(nn.LayerNorm):
         super().__init__(config.hidden_size, epsilon=config.rms_norm_eps)
         self.use_fast_ln = config.use_fast_ln
         self.ipp = ipp
-        if config.pipeline_parallel_degree > 1:
-            self.weight = dist.shard_tensor(
-                self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Replicate()]
-            )
-            self.bias = dist.shard_tensor(
-                self.bias, get_mesh(self.ipp), [dist.Replicate(), dist.Replicate()]
-            )
+        # if config.pipeline_parallel_degree > 1:
+        #     self.weight = dist.shard_tensor(
+        #         self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Replicate()]
+        #     )
+        #     self.bias = dist.shard_tensor(
+        #         self.bias, get_mesh(self.ipp), [dist.Replicate(), dist.Replicate()]
+        #     )
 
 
 class RotaryEmbedding(nn.Layer):
@@ -528,42 +529,42 @@ class ErnieMLP(nn.Layer):
             self.intermediate_size, self.hidden_size, bias_attr=config.use_bias
         )
 
-        if do_shard_tensor and (
-            self.config.tensor_parallel_degree > 1
-            or self.config.pipeline_parallel_degree > 1
-        ):
-            self.gate_proj.weight = dist.shard_tensor(
-                self.gate_proj.weight,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(1)],
-            )
-            self.up_proj.weight = dist.shard_tensor(
-                self.up_proj.weight,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(1)],
-            )
-            if config.use_bias:
-                self.gate_proj.bias = dist.shard_tensor(
-                    self.gate_proj.bias,
-                    get_mesh(self.ipp),
-                    [dist.Replicate(), dist.Shard(0)],
-                )
-                self.up_proj.bias = dist.shard_tensor(
-                    self.up_proj.bias,
-                    get_mesh(self.ipp),
-                    [dist.Replicate(), dist.Shard(0)],
-                )
-            self.down_proj.weight = dist.shard_tensor(
-                self.down_proj.weight,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(0)],
-            )
-            if config.use_bias:
-                self.down_proj.bias = dist.shard_tensor(
-                    self.down_proj.bias,
-                    get_mesh(self.ipp),
-                    [dist.Replicate(), dist.Replicate()],
-                )
+        # if do_shard_tensor and (
+        #     self.config.tensor_parallel_degree > 1
+        #     or self.config.pipeline_parallel_degree > 1
+        # ):
+        #     self.gate_proj.weight = dist.shard_tensor(
+        #         self.gate_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(1)],
+        #     )
+        #     self.up_proj.weight = dist.shard_tensor(
+        #         self.up_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(1)],
+        #     )
+        #     if config.use_bias:
+        #         self.gate_proj.bias = dist.shard_tensor(
+        #             self.gate_proj.bias,
+        #             get_mesh(self.ipp),
+        #             [dist.Replicate(), dist.Shard(0)],
+        #         )
+        #         self.up_proj.bias = dist.shard_tensor(
+        #             self.up_proj.bias,
+        #             get_mesh(self.ipp),
+        #             [dist.Replicate(), dist.Shard(0)],
+        #         )
+        #     self.down_proj.weight = dist.shard_tensor(
+        #         self.down_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(0)],
+        #     )
+        #     if config.use_bias:
+        #         self.down_proj.bias = dist.shard_tensor(
+        #             self.down_proj.bias,
+        #             get_mesh(self.ipp),
+        #             [dist.Replicate(), dist.Replicate()],
+        #         )
 
         self.fuse_swiglu = config.fuse_swiglu
 
@@ -574,8 +575,8 @@ class ErnieMLP(nn.Layer):
             x = F.silu(self.gate_proj(x)) * self.up_proj(x)
 
         out = self.down_proj(x)
-        if self.config.sequence_parallel:
-            out = dist.reshard(out, get_mesh(self.ipp), [dist.Shard(1), dist.Shard(0)])
+        # if self.config.sequence_parallel:
+        #     out = dist.reshard(out, get_mesh(self.ipp), [dist.Shard(1), dist.Shard(0)])
         return out
 
 
@@ -639,43 +640,47 @@ class ErnieAttentionAuto(nn.Layer):
             )
 
         self.config = config
-
-        self.q_proj.weight = dist.shard_tensor(
-            self.q_proj.weight,
-            get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
-        )
-        self.k_proj.weight = dist.shard_tensor(
-            self.k_proj.weight,
-            get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
-        )
-        self.v_proj.weight = dist.shard_tensor(
-            self.v_proj.weight,
-            get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(1)],
-        )
-        if config.use_bias:
-            self.q_proj.bias = dist.shard_tensor(
-                self.q_proj.bias,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(0)],
-            )
-            self.k_proj.bias = dist.shard_tensor(
-                self.k_proj.bias,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(0)],
-            )
-            self.v_proj.bias = dist.shard_tensor(
-                self.v_proj.bias,
-                get_mesh(self.ipp),
-                [dist.Replicate(), dist.Shard(0)],
-            )
-        self.o_proj.weight = dist.shard_tensor(
-            self.o_proj.weight,
-            get_mesh(self.ipp),
-            [dist.Replicate(), dist.Shard(0)],
-        )
+        self.reshard_row_and_col = ReshardLayer()
+        # if (
+        #     self.config.tensor_parallel_degree > 1
+        #     or self.config.pipeline_parallel_degree > 1
+        # ):
+        #     self.q_proj.weight = dist.shard_tensor(
+        #         self.q_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(1)],
+        #     )
+        #     self.k_proj.weight = dist.shard_tensor(
+        #         self.k_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(1)],
+        #     )
+        #     self.v_proj.weight = dist.shard_tensor(
+        #         self.v_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(1)],
+        #     )
+        #     if config.use_bias:
+        #         self.q_proj.bias = dist.shard_tensor(
+        #             self.q_proj.bias,
+        #             get_mesh(self.ipp),
+        #             [dist.Replicate(), dist.Shard(0)],
+        #         )
+        #         self.k_proj.bias = dist.shard_tensor(
+        #             self.k_proj.bias,
+        #             get_mesh(self.ipp),
+        #             [dist.Replicate(), dist.Shard(0)],
+        #         )
+        #         self.v_proj.bias = dist.shard_tensor(
+        #             self.v_proj.bias,
+        #             get_mesh(self.ipp),
+        #             [dist.Replicate(), dist.Shard(0)],
+        #         )
+        #     self.o_proj.weight = dist.shard_tensor(
+        #         self.o_proj.weight,
+        #         get_mesh(self.ipp),
+        #         [dist.Replicate(), dist.Shard(0)],
+        #     )
 
     def forward(
         self,
@@ -687,10 +692,10 @@ class ErnieAttentionAuto(nn.Layer):
         use_cache: bool = False,
         inbatch_pack_offset: Optional[Tuple[paddle.Tensor]] = None,
     ) -> Tuple[paddle.Tensor, Optional[paddle.Tensor], Optional[Tuple[paddle.Tensor]]]:
-        if self.config.sequence_parallel:
-            hidden_states = dist.reshard(
-                hidden_states, get_mesh(self.ipp), [dist.Shard(1), dist.Replicate()]
-            )
+        # if self.config.sequence_parallel:
+        #     hidden_states = dist.reshard(
+        #         hidden_states, get_mesh(self.ipp), [dist.Shard(1), dist.Replicate()]
+        #     )
 
         query_states = self.q_proj(hidden_states).reshape(
             shape=[0, 0, self.num_heads, self.head_dim]
@@ -712,10 +717,10 @@ class ErnieAttentionAuto(nn.Layer):
             ]
         )
 
-        if self.config.sequence_parallel:
-            query_states = paddle.transpose(query_states, [1, 0, 2, 3])
-            key_states = paddle.transpose(key_states, [1, 0, 2, 3])
-            value_states = paddle.transpose(value_states, [1, 0, 2, 3])
+        # if self.config.sequence_parallel:
+        #     query_states = paddle.transpose(query_states, [1, 0, 2, 3])
+        #     key_states = paddle.transpose(key_states, [1, 0, 2, 3])
+        #     value_states = paddle.transpose(value_states, [1, 0, 2, 3])
 
         if self.use_recompute_attn:
             assert past_key_value is None, "do not use kv cache in recompute"
@@ -736,25 +741,26 @@ class ErnieAttentionAuto(nn.Layer):
             )
         else:
             attn_output, attn_weights, past_key_value = self.rope_attn(
-                mix_layer=None,
-                query_states=query_states,
-                key_states=key_states,
-                value_states=value_states,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                output_attentions=output_attentions,
-                past_key_value=past_key_value,
-                use_cache=use_cache,
-                inbatch_pack_offset=inbatch_pack_offset,
+                None,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                position_ids,
+                output_attentions,
+                past_key_value,
+                use_cache,
+                inbatch_pack_offset,
             )
 
-        if self.config.sequence_parallel:
-            attn_output = self.o_proj(paddle.transpose(attn_output, [1, 0, 2]))
-            attn_output = dist.reshard(
-                attn_output, get_mesh(self.ipp), [dist.Shard(1), dist.Shard(0)]
-            )
-        else:
-            attn_output = self.o_proj(attn_output)
+        # if self.config.sequence_parallel:
+        #     attn_output = self.o_proj(paddle.transpose(attn_output, [1, 0, 2]))
+        #     attn_output = dist.reshard(
+        #         attn_output, get_mesh(self.ipp), [dist.Shard(1), dist.Shard(0)]
+        #     )
+        # else:
+        attn_output = self.o_proj(attn_output)
+        attn_output = self.reshard_row_and_col(attn_output)
 
         if not output_attentions:
             attn_weights = None
@@ -1003,6 +1009,7 @@ class ErnieDecoderLayerAuto(nn.Layer):
         self.residual_add2 = FusedDropoutAdd(
             config.hidden_dropout_prob, mode="upscale_in_train"
         )
+        self.reshard_col = ReshardLayer()
 
     def create_moe_mlp_layer(self, layer_idx, ipp):
         _ex_cfg = deepcopy(self.config)
@@ -1077,16 +1084,16 @@ class ErnieDecoderLayerAuto(nn.Layer):
         self.mlp = MOELayerAuto(
             gate,
             experts,
-            layer_idx=layer_idx,
-            shared_experts=shared_experts,
-            group=self.config.moe_group,
-            recompute=self.config.use_recompute_moe,
-            k=self.config.moe_k,
-            all_to_all_dropout=self.config.moe_all_to_all_dropout,
-            group_experts=self.config.moe_group_experts,
-            moe_statics=moe_statics,
-            config=self.config,
-            ipp=self.ipp,
+            layer_idx,
+            shared_experts,
+            self.config.moe_group,
+            self.config.use_recompute_moe,
+            self.config.moe_k,
+            self.config.moe_all_to_all_dropout,
+            self.config.moe_group_experts,
+            moe_statics,
+            self.config,
+            self.ipp,
         )
 
     def forward(
@@ -1120,13 +1127,13 @@ class ErnieDecoderLayerAuto(nn.Layer):
 
         (hidden_states, self_attn_weights, present_key_value, *router_loss_attn) = (
             self.self_attn(
-                hidden_states=hidden_states,
-                past_key_value=past_key_value,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                output_attentions=output_attentions,
-                use_cache=use_cache,
-                inbatch_pack_offset=inbatch_pack_offset,
+                hidden_states,
+                past_key_value,
+                attention_mask,
+                position_ids,
+                output_attentions,
+                use_cache,
+                inbatch_pack_offset,
             )
         )
 
@@ -1153,12 +1160,13 @@ class ErnieDecoderLayerAuto(nn.Layer):
                 hidden_states, token_type_ids
             )
         else:
-            if self.config.sequence_parallel:
-                hidden_states = dist.reshard(
-                    hidden_states,
-                    get_mesh(self.ipp),
-                    [dist.Shard(1), dist.Replicate()],
-                )
+            # if self.config.sequence_parallel:
+            #     hidden_states = dist.reshard(
+            #         hidden_states,
+            #         get_mesh(self.ipp),
+            #         [dist.Shard(1), dist.Replicate()],
+            #     )
+            hidden_states = self.reshard_col(hidden_states)
             hidden_states = self.mlp(hidden_states)
             gate_logits = None
 
@@ -1306,11 +1314,11 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
                 self.vocab_size,
                 self.hidden_size,
             )
-            self.embed_tokens.weight = dist.shard_tensor(
-                self.embed_tokens.weight,
-                get_mesh(pp_idx=0),
-                [dist.Replicate(), dist.Shard(1)],
-            )
+            # self.embed_tokens.weight = dist.shard_tensor(
+            #     self.embed_tokens.weight,
+            #     get_mesh(pp_idx=0),
+            #     [dist.Replicate(), dist.Shard(1)],
+            # )
         if config.pipeline_parallel_degree <= 1:
             self.layers = nn.LayerList()
             for idx in range(
@@ -1329,11 +1337,11 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
 
         self.gradient_checkpointing = False
 
-        self.placements = (
-            [dist.Shard(1), dist.Shard(0)]
-            if self.config.sequence_parallel
-            else [dist.Shard(0), dist.Replicate()]
-        )
+        # self.placements = (
+        #     [dist.Shard(1), dist.Shard(0)]
+        #     if self.config.sequence_parallel
+        #     else [dist.Shard(0), dist.Replicate()]
+        # )
         self.all_gate_logits = () if hasattr(self.config, "use_moe") else None
         self.inbatch_pack_offset = None
         self.token_type_ids = None
@@ -1440,8 +1448,8 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
             )
 
         global_mesh = get_mesh(pp_idx=None)
-        if self.config.sequence_parallel:
-            inputs_embeds = paddle.transpose(inputs_embeds, [1, 0, 2])
+        # if self.config.sequence_parallel:
+        #     inputs_embeds = paddle.transpose(inputs_embeds, [1, 0, 2])
 
         if position_ids is not None:
             position_ids = dist.shard_tensor(
@@ -1473,9 +1481,9 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
                 [dist.Replicate() for _ in range(len(global_mesh._shape))],
             )
 
-        hidden_states = dist.reshard(inputs_embeds, get_mesh(0), self.placements)
+        # hidden_states = dist.reshard(inputs_embeds, get_mesh(0), self.placements)
 
-        return hidden_states, attention_mask, position_ids
+        return inputs_embeds, attention_mask, position_ids
 
     def decode_layer(
         self,
@@ -1697,15 +1705,15 @@ class ErnieLMHead(nn.Layer):
             dtype=paddle.get_default_dtype(),
         )
 
-        if (
-            self.config.tensor_parallel_degree > 1
-            or self.config.pipeline_parallel_degree > 1
-        ):
-            self.weight = dist.shard_tensor(
-                self.weight,
-                get_mesh(-1),
-                [dist.Replicate(), dist.Shard(1)],
-            )
+        # if (
+        #     self.config.tensor_parallel_degree > 1
+        #     or self.config.pipeline_parallel_degree > 1
+        # ):
+        #     self.weight = dist.shard_tensor(
+        #         self.weight,
+        #         get_mesh(-1),
+        #         [dist.Replicate(), dist.Shard(1)],
+        #     )
         self.weight.is_distributed = False
 
         logger.info(
@@ -1719,15 +1727,15 @@ class ErnieLMHead(nn.Layer):
                     initializer=paddle.nn.initializer.constant.Constant(0.0)
                 ),
             )
-            if (
-                self.config.tensor_parallel_degree > 1
-                or self.config.pipeline_parallel_degree > 1
-            ):
-                self.bias = dist.shard_tensor(
-                    self.bias,
-                    get_mesh(-1),
-                    [dist.Replicate(), dist.Shard(0)],
-                )
+            # if (
+            #     self.config.tensor_parallel_degree > 1
+            #     or self.config.pipeline_parallel_degree > 1
+            # ):
+            #     self.bias = dist.shard_tensor(
+            #         self.bias,
+            #         get_mesh(-1),
+            #         [dist.Replicate(), dist.Shard(0)],
+            #     )
             self.bias.is_distributed = False
         else:
             self.bias = None
@@ -1799,17 +1807,17 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
             chunk_size = (
                 config.num_hidden_layers // pp_degree // config.virtual_pp_degree
             )
-            current_rank = (
-                fleet.get_hybrid_communicate_group().get_pipe_parallel_group().rank
-                % pp_degree
-            )
+            # current_rank = (
+            #     fleet.get_hybrid_communicate_group().get_pipe_parallel_group().rank
+            #     % pp_degree
+            # )
             for idx in range(config.num_hidden_layers):
                 target_stage = (idx // chunk_size) % pp_degree
-                if target_stage == current_rank:
-                    stage_id = (idx // chunk_size) % pp_degree
-                    self.layers.append(ErnieModelAutoPP(config, idx, stage_id))
-                else:
-                    self.layers.append(nn.Identity())
+                # if target_stage == current_rank:
+                #     stage_id = (idx // chunk_size) % pp_degree
+                self.layers.append(ErnieModelAutoPP(config, idx, target_stage))
+                # else:
+                #     self.layers.append(nn.Identity())
         else:
             self.ernie = ErnieModelAuto(config)
             self.lm_head = ErnieLMHead(config)
@@ -1946,3 +1954,108 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
             else None
         )
         return self.criterion(logits, labels, router_loss)
+
+    def auto_dist_config(self, prefix=""):
+        if prefix != "":
+            assert prefix.endswith(".")
+        if self.config.pipeline_parallel_degree <= 1:
+            ernie_prefix = prefix + "ernie."
+            layers_prefix = ""
+        else:
+            ernie_prefix = prefix
+            layers_prefix = "layers.*."
+        config = {
+            "sp_config": {
+                "parallelize_plan": {
+                    f"{ernie_prefix}{layers_prefix}embed_tokens": [
+                        dist.ColWiseParallel(),
+                        dist.SequenceParallelBegin(),
+                    ],
+                    f"{ernie_prefix}layers.*.self_attn": dist.SequenceParallelDisable(),
+                    f"{ernie_prefix}layers.*.self_attn.q_proj": dist.ColWiseParallel(),
+                    f"{ernie_prefix}layers.*.self_attn.k_proj": dist.ColWiseParallel(),
+                    f"{ernie_prefix}layers.*.self_attn.v_proj": dist.ColWiseParallel(),
+                    f"{ernie_prefix}layers.*.self_attn.o_proj": dist.RowWiseParallel(),
+                    f"{ernie_prefix}layers.*.self_attn.reshard_row_and_col": PrepareLayerInput(
+                        layer_input_reshard_row_and_col_hook
+                    ),
+                    f"{ernie_prefix}layers.*.reshard_col": PrepareLayerInput(
+                        layer_input_reshard_col_hook
+                    ),
+                    f"{ernie_prefix}layers.*.mlp": dist.SequenceParallelDisable(
+                        need_transpose=False
+                    ),
+                    f"{ernie_prefix}layers.*.mlp.gate_proj": dist.ColWiseParallel(),
+                    f"{ernie_prefix}layers.*.mlp.up_proj": dist.ColWiseParallel(),
+                    f"{ernie_prefix}layers.*.mlp.down_proj": dist.RowWiseParallel(),
+                    f"{prefix}{layers_prefix}lm_head.weight": dist.ColWiseParallel(),  # has diff
+                    f"{prefix}{layers_prefix}lm_head": dist.SequenceParallelEnd(),
+                }
+            },
+            "mp_config": {
+                "parallelize_plan": {
+                    f"{prefix}ernie.embed_tokens": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.self_attn.q_proj": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.self_attn.k_proj": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.self_attn.v_proj": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.self_attn.o_proj": dist.RowWiseParallel(),
+                    f"{prefix}ernie.layers.*.mlp.gate_proj": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.mlp.up_proj": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.mlp.down_proj": dist.RowWiseParallel(),
+                    f"{prefix}lm_head.weight": dist.ColWiseParallel(),
+                }
+            },
+            "pp_config": {
+                "split_spec": f"{prefix}layers",
+            },
+        }
+
+        return config
+
+
+class ReshardLayer(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input
+
+
+def layer_input_reshard_row_and_col_hook(process_mesh):
+    def hook(layer, inputs, output=None):
+        res_inputs = []
+        for input in inputs:
+            if not input.is_dist():
+                x = dist.shard_tensor(
+                    input, process_mesh, [dist.Shard(0), dist.Shard(1)]
+                )
+                res_inputs.append(
+                    dist.reshard(x, process_mesh, [dist.Shard(0), dist.Shard(1)])
+                )
+            else:
+                res_inputs.append(
+                    dist.reshard(input, process_mesh, [dist.Shard(0), dist.Shard(1)])
+                )
+        return tuple(res_inputs)
+
+    return hook
+
+
+def layer_input_reshard_col_hook(process_mesh):
+    def hook(layer, inputs, output=None):
+        res_inputs = []
+        for input in inputs:
+            if not input.is_dist():
+                x = dist.shard_tensor(
+                    input, process_mesh, [dist.Shard(1), dist.Replicate()]
+                )
+                res_inputs.append(
+                    dist.reshard(x, process_mesh, [dist.Shard(1), dist.Replicate()])
+                )
+            else:
+                res_inputs.append(
+                    dist.reshard(input, process_mesh, [dist.Shard(1), dist.Replicate()])
+                )
+        return tuple(res_inputs)
+
+    return hook

--- a/examples/auto_parallel/models/modeling_auto.py
+++ b/examples/auto_parallel/models/modeling_auto.py
@@ -31,9 +31,6 @@ from paddle.distributed.fleet.layers.mpu.random import get_rng_state_tracker
 
 from models.top2_gate_auto import TopKGateFusedAuto
 
-from paddle.distributed.auto_parallel.intermediate.tensor_parallel import (
-    PrepareLayerInput,
-)
 from paddleformers.transformers.model_outputs import (
     BaseModelOutputWithPastAndCrossAttentions as _BaseModelOutput,
 )
@@ -58,7 +55,6 @@ from paddle.incubate.nn.functional import swiglu
 class BaseModelOutputWithPastAndCrossAttentions(_BaseModelOutput):
     router_loss: Optional[paddle.Tensor] = None
     gate_logits: Optional[Tuple[paddle.Tensor]] = None
-    mtp_outputs: Optional[paddle.Tensor] = None
 
 
 @dataclass
@@ -1167,7 +1163,7 @@ class ErnieDecoderLayerAuto(nn.Layer):
             #         get_mesh(self.ipp),
             #         [dist.Shard(1), dist.Replicate()],
             #     )
-            hidden_states = self.reshard_col(hidden_states)
+            # hidden_states = self.reshard_col(hidden_states)
             hidden_states = self.mlp(hidden_states)
             gate_logits = None
 
@@ -1199,7 +1195,12 @@ class ErnieDecoderLayerAuto(nn.Layer):
             if isinstance(self.mlp, (MOELayerAuto)):
                 outputs += (router_loss,)
             else:
-                outputs += (paddle.zeros([1], dtype=paddle.float32),)
+                new_tensor = dist.shard_tensor(
+                    paddle.zeros([1], dtype=paddle.float32),
+                    get_mesh(self.ipp),
+                    [dist.Replicate(), dist.Replicate()],
+                )
+                outputs += (new_tensor,)
 
             if output_gate_logits:
                 outputs += (gate_logits,)
@@ -1304,37 +1305,34 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         config: ErnieMoEConfig
     """
 
-    def __init__(self, config: ErnieMoEConfig, pp_layer_idx=None):
+    def __init__(self, config: ErnieMoEConfig):
         super().__init__(config)
         self.padding_idx = config.pad_token_id
         self.config = config
-        if config.pipeline_parallel_degree <= 1 or pp_layer_idx == 0:
-            self.vocab_size = config.vocab_size
-            self.hidden_size = config.hidden_size
-            self.embed_tokens = nn.Embedding(
-                self.vocab_size,
-                self.hidden_size,
-            )
-            # self.embed_tokens.weight = dist.shard_tensor(
-            #     self.embed_tokens.weight,
-            #     get_mesh(pp_idx=0),
-            #     [dist.Replicate(), dist.Shard(1)],
-            # )
-        if config.pipeline_parallel_degree <= 1:
-            self.layers = nn.LayerList()
-            for idx in range(
-                config.num_hidden_layers - 1
-                if config.remove_tail_layer
-                else config.num_hidden_layers
-            ):
-                self.layers.append(ErnieDecoderLayerAuto(config, idx))
-        if (
-            config.pipeline_parallel_degree <= 1
-            or pp_layer_idx == self.config.num_hidden_layers - 1
+
+        self.vocab_size = config.vocab_size
+        self.hidden_size = config.hidden_size
+        self.embed_tokens = nn.Embedding(
+            self.vocab_size,
+            self.hidden_size,
+        )
+        # self.embed_tokens.weight = dist.shard_tensor(
+        #     self.embed_tokens.weight,
+        #     get_mesh(pp_idx=0),
+        #     [dist.Replicate(), dist.Shard(1)],
+        # )
+
+        self.layers = nn.LayerList()
+        for idx in range(
+            config.num_hidden_layers - 1
+            if config.remove_tail_layer
+            else config.num_hidden_layers
         ):
-            Norm = RMSNorm if config.use_rmsnorm else LayerNorm
-            self.norm = Norm(config, -1)
-            self.lm_head = ErnieLMHead(config)
+            self.layers.append(ErnieDecoderLayerAuto(config, idx))
+
+        Norm = RMSNorm if config.use_rmsnorm else LayerNorm
+        self.norm = Norm(config, -1)
+        self.lm_head = ErnieLMHead(config)
 
         self.gradient_checkpointing = False
 
@@ -1343,38 +1341,6 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         #     if self.config.sequence_parallel
         #     else [dist.Shard(0), dist.Replicate()]
         # )
-
-        if self.config.multi_token_pred_depth > 0:
-            Norm = RMSNorm if config.use_rmsnorm else LayerNorm
-            self.mtp_block = nn.LayerList(
-                [
-                    ErnieDecoderLayerAuto(config, layer_idx, -1)
-                    for layer_idx in range(self.config.multi_token_pred_depth)
-                ]
-            )
-            self.mtp_hidden_norm = nn.LayerList(
-                [Norm(config, -1) for _ in range(self.config.multi_token_pred_depth)]
-            )
-            self.mtp_emb_norm = nn.LayerList(
-                [Norm(config, -1) for _ in range(self.config.multi_token_pred_depth)]
-            )
-
-            LinearFN = (
-                paddle.incubate.nn.FusedLinear
-                if config.fuse_linear
-                else paddle.nn.Linear
-            )
-            self.mtp_linear_proj = nn.LayerList(
-                [
-                    LinearFN(
-                        self.config.hidden_size * 2,
-                        self.config.hidden_size,
-                        bias_attr=config.use_bias,
-                    )
-                    for _ in range(self.config.multi_token_pred_depth)
-                ]
-            )
-
         self.all_gate_logits = () if hasattr(self.config, "use_moe") else None
         self.inbatch_pack_offset = None
         self.token_type_ids = None
@@ -1384,7 +1350,6 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         self.all_hidden_states = None
         self.all_self_attns = None
         self.next_decoder_cache = None
-        self.inputs_embeds_cur_depth_list = None
 
     def get_input_embeddings(self):
         return self.embed_tokens
@@ -1469,7 +1434,6 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         if self.past_key_values is None:
             past_key_values = tuple([None] * self.config.num_hidden_layers)
 
-        seq_length -= self.config.multi_token_pred_depth
         seq_length_with_past = seq_length
         cache_length = 0
 
@@ -1481,26 +1445,6 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
             inputs_embeds = self.embed_tokens(input_ids).astype(
                 self.embed_tokens.weight.dtype
             )
-
-        if self.config.multi_token_pred_depth > 0:
-            inputs_embeds_extra = inputs_embeds[
-                :, -self.config.multi_token_pred_depth :, :
-            ]  # [B, S, D]
-            inputs_embeds = inputs_embeds[:, : -self.config.multi_token_pred_depth, :]
-            inputs_embeds_ori = inputs_embeds
-            inputs_embeds_cur_depth_list = []
-            for depth in range(self.config.multi_token_pred_depth):
-                inputs_embeds_cur_depth = paddle.concat(
-                    [
-                        inputs_embeds_ori[:, (depth + 1) :, :],
-                        inputs_embeds_extra[:, : (depth + 1), :],
-                    ],
-                    axis=1,
-                )
-                inputs_embeds_cur_depth_list.append(inputs_embeds_cur_depth)
-                self.inputs_embeds_cur_depth_list = paddle.concat(
-                    inputs_embeds_cur_depth_list
-                )
 
         global_mesh = get_mesh(pp_idx=None)
         # if self.config.sequence_parallel:
@@ -1538,15 +1482,7 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
 
         # hidden_states = dist.reshard(inputs_embeds, get_mesh(0), self.placements)
 
-        if self.config.multi_token_pred_depth > 0:
-            return (
-                inputs_embeds,
-                attention_mask,
-                position_ids,
-                self.inputs_embeds_cur_depth_list,
-            )
-        else:
-            return inputs_embeds, attention_mask, position_ids
+        return inputs_embeds, attention_mask, position_ids
 
     def decode_layer(
         self,
@@ -1603,77 +1539,12 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
             if not (self.config.use_recompute and has_gradient):
                 layer_outputs, gate_logits = layer_outputs[:-1], layer_outputs[-1]
                 self.all_gate_logits = self.all_gate_logits + (gate_logits,)
-            router_loss = layer_outputs[-1]
-            if all_router_loss is not None:
-                all_router_loss += router_loss
+            # router_loss = layer_outputs[-1]
+            # if all_router_loss is not None:
+            # print(all_router_loss)
+            # print(router_loss)
+            # all_router_loss += router_loss
         return hidden_states, all_router_loss
-
-    def mtp_layer(
-        self, hidden_states, inputs_embeds_cur_depth_list, attention_mask, position_ids
-    ):
-        has_gradient = not hidden_states.stop_gradient
-        mtp_outputs = []
-        mtp_outputs.append(hidden_states)
-
-        for depth in range(self.config.multi_token_pred_depth):
-            if self.config.sequence_parallel or self.config.submatrix_parallel:
-                hidden_states = dist.reshard(
-                    hidden_states,
-                    get_mesh(-1),
-                    [dist.Replicate(), dist.Replicate()],
-                )
-                hidden_states = paddle.transpose(hidden_states, [1, 0, 2])
-
-            inputs_embeds_cur_depth = inputs_embeds_cur_depth_list[depth]
-
-            # Norm&Concat
-            inputs_embeds_cur_depth_norm = self.mtp_emb_norm[depth](
-                inputs_embeds_cur_depth
-            )
-            hidden_states_norm = self.mtp_hidden_norm[depth](hidden_states)
-            inputs_embeds_cur_depth = self.mtp_linear_proj[depth](
-                paddle.concat(
-                    [inputs_embeds_cur_depth_norm, hidden_states_norm], axis=-1
-                )
-            )
-
-            # scatter
-            if self.config.sequence_parallel or self.config.submatrix_parallel:
-                inputs_embeds_cur_depth = paddle.transpose(
-                    inputs_embeds_cur_depth, [1, 0, 2]
-                )
-                inputs_embeds_cur_depth = dist.reshard(
-                    inputs_embeds_cur_depth,
-                    get_mesh(-1),
-                    self.placements,
-                )
-
-            decoder_layer = self.mtp_block[depth]
-            past_key_values = None
-            layer_outputs = decoder_layer(
-                inputs_embeds_cur_depth,
-                attention_mask,
-                position_ids,
-                self.config.output_attentions,
-                past_key_values,
-                self.config.use_cache,
-                self.inbatch_pack_offset,
-                self.token_type_ids,
-            )
-
-            if isinstance(layer_outputs, (tuple, list)):
-                hidden_states = layer_outputs[0]
-            else:
-                hidden_states = layer_outputs
-
-            if self.config.use_moe:
-                if not (self.config.use_recompute and has_gradient):
-                    layer_outputs, gate_logits = layer_outputs[:-1], layer_outputs[-1]
-                    self.all_gate_logits = self.all_gate_logits + (gate_logits,)
-
-            mtp_outputs.append(hidden_states)
-        mtp_outputs = [self.norm(hidden_states) for hidden_states in mtp_outputs]
-        return mtp_outputs
 
     def forward(
         self,
@@ -1704,17 +1575,9 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         if output_attentions is not None:
             self.config.output_attentions = output_attentions
 
-        if self.config.multi_token_pred_depth > 0:
-            (
-                hidden_states,
-                attention_mask,
-                position_ids,
-                inputs_embeds_cur_depth_list,
-            ) = self.embed_inputs(input_ids, attention_mask, position_ids)
-        else:
-            hidden_states, attention_mask, position_ids = self.embed_inputs(
-                input_ids, attention_mask, position_ids
-            )
+        hidden_states, attention_mask, position_ids = self.embed_inputs(
+            input_ids, attention_mask, position_ids
+        )
 
         self.all_hidden_states = () if output_hidden_states else None
         self.all_self_attns = () if output_attentions else None
@@ -1723,6 +1586,9 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         all_router_loss = None
         if hasattr(self.config, "use_moe") and self.config.use_moe:
             all_router_loss = paddle.to_tensor(0.0)
+            # all_router_loss = dist.shard_tensor(
+            #     all_router_loss, self.embed_tokens.process_mesh, [dist.Replicate(), dist.Replicate()]
+            # )
 
         for idx, (decoder_layer) in enumerate(self.layers):
             hidden_states, all_router_loss = self.decode_layer(
@@ -1736,21 +1602,7 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
         if use_cache and not (hasattr(self.config, "use_moe") and self.config.use_moe):
             hidden_states = paddle.unsqueeze(hidden_states[:, -1, :], 1)
 
-        # Multi Token Prediction
-        mtp_outputs = []
-        if self.config.multi_token_pred_depth > 0:
-            inputs_embeds_cur_depth_list = paddle.split(
-                inputs_embeds_cur_depth_list, self.config.multi_token_pred_depth
-            )
-            mtp_outputs = self.mtp_layer(
-                hidden_states,
-                inputs_embeds_cur_depth_list,
-                attention_mask,
-                position_ids,
-            )
-            hidden_states, mtp_outputs = mtp_outputs[0], mtp_outputs[1:]
-        else:
-            hidden_states = self.norm(hidden_states)
+        hidden_states = self.norm(hidden_states)
 
         if output_hidden_states:
             self.all_hidden_states += (hidden_states,)
@@ -1767,7 +1619,6 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
                     self.all_self_attns,
                     all_router_loss,
                     self.all_gate_logits,
-                    mtp_outputs,
                 ]
                 if v is not None
             )
@@ -1779,7 +1630,6 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
             cross_attentions=None,
             router_loss=all_router_loss,
             gate_logits=self.all_gate_logits,
-            mtp_outputs=mtp_outputs,
         )
 
 
@@ -1803,56 +1653,11 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
         """
         calculates the final loss
         """
-        if self.config.multi_token_pred_depth > 0:
-            # prediction_scores :[logits, mtp_logits]
-            logits = paddle.split(
-                prediction_scores, self.config.multi_token_pred_depth + 1
-            )
-            prediction_scores = logits[0]
-            mtp_logits = logits[1:]
-            masked_lm_labels_ori = masked_lm_labels
-            masked_lm_labels = masked_lm_labels[
-                :, : -self.config.multi_token_pred_depth
-            ]
-            seq_length = masked_lm_labels.shape[1]
         res = self.forward_impl(prediction_scores, masked_lm_labels)
-        if self.config.multi_token_pred_depth > 0:
-            mtp_loss_res = []
-            for depth in range(self.config.multi_token_pred_depth):
-                prediction_scores_cur_depth = mtp_logits[depth]
-                masked_lm_labels_cur_depth = masked_lm_labels_ori[
-                    :, (depth + 1) : (depth + 1 + seq_length)
-                ]
-                res_cur_depth = self.forward_impl(
-                    prediction_scores_cur_depth,
-                    masked_lm_labels_cur_depth,
-                )
-                mtp_loss_res.append(res_cur_depth)
-
-        def add_loss(main_loss, loss):
-            return main_loss + loss - loss.detach()
-
         if self.return_tuple:
             loss, loss_sum = res
-            if self.config.multi_token_pred_depth > 0:
-                loss = add_loss(
-                    loss,
-                    self.config.multi_token_pred_lambda
-                    * sum([x[0] for x in mtp_loss_res])
-                    / len(mtp_loss_res),
-                )
-                loss_sum = loss_sum + self.config.multi_token_pred_lambda * sum(
-                    [x[1].detach() for x in mtp_loss_res]
-                ) / len(mtp_loss_res)
         else:
             loss, loss_sum = res, None
-            if self.config.multi_token_pred_depth > 0:
-                loss = add_loss(
-                    loss,
-                    self.config.multi_token_pred_lambda
-                    * sum(mtp_loss_res)
-                    / len(mtp_loss_res),
-                )
         if router_loss is not None:
             loss = loss + router_loss - router_loss.detach()
         if not self.return_tuple:
@@ -1956,67 +1761,32 @@ class ErnieLMHead(nn.Layer):
         )
 
 
-class ErnieModelAutoPP(ErnieModelAuto):
-    def __init__(self, config, layer_idx=0, ipp=0):
-        super().__init__(config, layer_idx)
-        self.layer = ErnieDecoderLayerAuto(config, layer_idx, ipp)
+# class ErnieModelAutoPP(ErnieModelAuto):
+#     def __init__(self, config, layer_idx=0, ipp=0):
+#         super().__init__(config, layer_idx)
+#         self.layer = ErnieDecoderLayerAuto(config, layer_idx, ipp)
 
-    def forward(self, args):
-        attention_mask, position_ids = None, None
-        if isinstance(args, tuple):
-            hidden_states = args[0] if len(args) > 0 else args
-            attention_mask = args[1] if len(args) > 1 else None
-            position_ids = args[2] if len(args) > 2 else None
-
-            if len(args) == 2 and self.config.multi_token_pred_depth > 0:
-                hidden_states = args[0]
-                inputs_embeds_cur_depth_list = args[1]
-        else:
-            hidden_states = args
-        if self.layer.layer_idx == 0:
-            if self.config.multi_token_pred_depth > 0:
-                (
-                    hidden_states,
-                    attention_mask,
-                    position_ids,
-                    inputs_embeds_cur_depth_list,
-                ) = self.embed_inputs(hidden_states, attention_mask, position_ids)
-            else:
-                hidden_states, attention_mask, position_ids = self.embed_inputs(
-                    hidden_states, attention_mask, position_ids
-                )
-        hidden_states, _ = self.decode_layer(
-            self.layer, hidden_states, attention_mask, position_ids
-        )
-        if self.layer.layer_idx == self.config.num_hidden_layers - 1:
-            # Multi Token Prediction
-            mtp_outputs = []
-            if self.config.multi_token_pred_depth > 0:
-                inputs_embeds_cur_depth_list = paddle.split(
-                    inputs_embeds_cur_depth_list, self.config.multi_token_pred_depth
-                )
-                mtp_outputs = self.mtp_layer(
-                    hidden_states,
-                    inputs_embeds_cur_depth_list,
-                    attention_mask,
-                    position_ids,
-                )
-                hidden_states, mtp_outputs = mtp_outputs[0], mtp_outputs[1:]
-            else:
-                hidden_states = self.norm(hidden_states)
-            logits = self.lm_head(hidden_states)
-
-            if self.config.multi_token_pred_depth > 0:
-                mtp_logits = [logits]
-                for _hidden_states in mtp_outputs:
-                    mtp_logits.append(self.lm_head(_hidden_states))
-                logits = paddle.concat(mtp_logits)
-            return logits
-        else:
-            if self.config.multi_token_pred_depth > 0:
-                return hidden_states, inputs_embeds_cur_depth_list
-            else:
-                return hidden_states
+#     def forward(self, args):
+#         attention_mask, position_ids = None, None
+#         if isinstance(args, tuple):
+#             hidden_states = args[0] if len(args) > 0 else args
+#             attention_mask = args[1] if len(args) > 1 else None
+#             position_ids = args[2] if len(args) > 2 else None
+#         else:
+#             hidden_states = args
+#         if self.layer.layer_idx == 0:
+#             hidden_states, attention_mask, position_ids = self.embed_inputs(
+#                 hidden_states, attention_mask, position_ids
+#             )
+#         hidden_states, _ = self.decode_layer(
+#             self.layer, hidden_states, attention_mask, position_ids
+#         )
+#         if self.layer.layer_idx == self.config.num_hidden_layers - 1:
+#             hidden_states = self.norm(hidden_states)
+#             logits = self.lm_head(hidden_states)
+#             return logits
+#         else:
+#             return hidden_states
 
 
 class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
@@ -2035,26 +1805,22 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
 
         self.tie_weights()
 
-        if config.pipeline_parallel_degree > 1:
-            self.layers = nn.LayerList()
-            pp_degree = config.pipeline_parallel_degree
-            chunk_size = (
-                config.num_hidden_layers // pp_degree // config.virtual_pp_degree
-            )
-            # current_rank = (
-            #     fleet.get_hybrid_communicate_group().get_pipe_parallel_group().rank
-            #     % pp_degree
-            # )
-            for idx in range(config.num_hidden_layers):
-                target_stage = (idx // chunk_size) % pp_degree
-                # if target_stage == current_rank:
-                #     stage_id = (idx // chunk_size) % pp_degree
-                self.layers.append(ErnieModelAutoPP(config, idx, target_stage))
-                # else:
-                #     self.layers.append(nn.Identity())
-        else:
-            self.ernie = ErnieModelAuto(config)
-            self.lm_head = ErnieLMHead(config)
+        # if config.pipeline_parallel_degree > 1:
+        #     self.layers = nn.LayerList()
+        #     pp_degree = config.pipeline_parallel_degree
+        #     chunk_size = (
+        #         config.num_hidden_layers // pp_degree // config.virtual_pp_degree
+        #     )
+        #     for idx in range(config.num_hidden_layers):
+        #         target_stage = (idx // chunk_size) % pp_degree
+        #         # if target_stage == current_rank:
+        #         #     stage_id = (idx // chunk_size) % pp_degree
+        #         self.layers.append(ErnieModelAutoPP(config, idx, target_stage))
+        #         # else:
+        #         #     self.layers.append(nn.Identity())
+        # else:
+        self.ernie = ErnieModelAuto(config)
+        self.lm_head = ErnieLMHead(config)
 
     def _post_init(self, original_init, *args, **kwargs):
         """
@@ -2068,14 +1834,14 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
             if w.is_dist() and w._is_initialized():
                 w.scale_(factor)
 
-        if self.config.pipeline_parallel_degree > 1:
-            decoder_layers = []
-            for layer in self.layers:
-                if isinstance(layer, ErnieModelAutoPP):
-                    decoder_layers.append(layer.layer)
-            layers = decoder_layers
-        else:
-            layers = self.ernie.layers
+        # if self.config.pipeline_parallel_degree > 1:
+        #     decoder_layers = []
+        #     for layer in self.layers:
+        #         if isinstance(layer, ErnieModelAutoPP):
+        #             decoder_layers.append(layer.layer)
+        #     layers = decoder_layers
+        # else:
+        layers = self.ernie.layers
         if hasattr(self.config, "use_moe") and self.config.use_moe:
             with paddle.no_grad():
                 for left in layers:
@@ -2132,6 +1898,7 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
         inbatch_pack_offset=None,
         token_type_ids=None,
     ):
+
         if isinstance(input_ids, list):
             input_ids, labels = input_ids[:2]
 
@@ -2148,6 +1915,7 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
         return_dict = (
             return_dict if return_dict is not None else self.config.use_return_dict
         )
+
         outputs = self.ernie(
             input_ids,
             position_ids=position_ids,
@@ -2163,14 +1931,8 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
         )
 
         hidden_states = outputs.last_hidden_state
-        mtp_outputs = outputs.mtp_outputs
-        logits = self.lm_head(hidden_states)
 
-        mtp_logits = [logits]
-        if len(mtp_outputs) > 0:
-            for _hidden_states in mtp_outputs:
-                mtp_logits.append(self.lm_head(_hidden_states))
-            logits = paddle.concat(mtp_logits)
+        logits = self.lm_head(hidden_states)
 
         if return_dict:
             if labels is not None:
@@ -2192,17 +1954,20 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
             if hasattr(self.config, "use_moe") and self.config.use_moe
             else None
         )
+        # print(f"logits:{logits}")
+        # print(f"labels:{labels}")
+        # print(f"roter_loss:{router_loss}")
         return self.criterion(logits, labels, router_loss)
 
     def auto_dist_config(self, prefix=""):
         if prefix != "":
             assert prefix.endswith(".")
-        if self.config.pipeline_parallel_degree <= 1:
-            ernie_prefix = prefix + "ernie."
-            layers_prefix = ""
-        else:
-            ernie_prefix = prefix
-            layers_prefix = "layers.*."
+        # if self.config.pipeline_parallel_degree <= 1:
+        ernie_prefix = prefix + "ernie."
+        layers_prefix = ""
+        # else:
+        #     ernie_prefix = prefix
+        #     layers_prefix="layers.*."
         config = {
             "sp_config": {
                 "parallelize_plan": {
@@ -2215,12 +1980,8 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
                     f"{ernie_prefix}layers.*.self_attn.k_proj": dist.ColWiseParallel(),
                     f"{ernie_prefix}layers.*.self_attn.v_proj": dist.ColWiseParallel(),
                     f"{ernie_prefix}layers.*.self_attn.o_proj": dist.RowWiseParallel(),
-                    f"{ernie_prefix}layers.*.self_attn.reshard_row_and_col": PrepareLayerInput(
-                        layer_input_reshard_row_and_col_hook
-                    ),
-                    f"{ernie_prefix}layers.*.reshard_col": PrepareLayerInput(
-                        layer_input_reshard_col_hook
-                    ),
+                    # f"{ernie_prefix}layers.*.self_attn.reshard_row_and_col": PrepareLayerInput(layer_input_reshard_row_and_col_hook),
+                    # f"{ernie_prefix}layers.*.reshard_col": PrepareLayerInput(layer_input_reshard_col_hook),
                     f"{ernie_prefix}layers.*.mlp": dist.SequenceParallelDisable(
                         need_transpose=False
                     ),
@@ -2245,10 +2006,9 @@ class ErnieForCausalLMAuto(ErniePretrainedModelAuto):
                 }
             },
             "pp_config": {
-                "split_spec": f"{prefix}layers",
+                "split_spec": f"{prefix}ernie.layers",
             },
         }
-
         return config
 
 

--- a/examples/auto_parallel/models/modeling_auto.py
+++ b/examples/auto_parallel/models/modeling_auto.py
@@ -1540,14 +1540,13 @@ class ErnieModelAuto(ErniePretrainedModelAuto):
 
         if self.config.multi_token_pred_depth > 0:
             return (
-                hidden_states,
+                inputs_embeds,
                 attention_mask,
                 position_ids,
                 self.inputs_embeds_cur_depth_list,
             )
         else:
-            return hidden_states, attention_mask, position_ids
-
+            return inputs_embeds, attention_mask, position_ids
 
     def decode_layer(
         self,

--- a/examples/auto_parallel/pretrain_96_auto.yaml
+++ b/examples/auto_parallel/pretrain_96_auto.yaml
@@ -18,7 +18,7 @@ model_args:
     model_config:
         multi_token_pred_depth: 0
         moe_logging: True
-        moe_use_aux_free: true
+        moe_use_aux_free: False
         num_hidden_layers: 4
         use_cache: False
         use_fast_ln: True
@@ -76,8 +76,11 @@ trainer_args:
 
     tensor_parallel_degree: 4
     pipeline_parallel_degree: 2
-    virtual_pp_degree: 2
-    pipeline_schedule_mode: "VPP"
+    # virtual_pp_degree: 2
+    pipeline_schedule_mode: "FThenB"
+
+    # tensor_parallel_degree: 8
+    # pipeline_parallel_degree: 1
 
     data_parallel_degree: 1
     sharding: "stage1"

--- a/examples/auto_parallel/pretrain_96_auto.yaml
+++ b/examples/auto_parallel/pretrain_96_auto.yaml
@@ -103,4 +103,5 @@ trainer_args:
     gc_interval: 100000
 
     enable_auto_parallel: 1
+    use_intermediate_api: True
     to_static: 0

--- a/examples/auto_parallel/trainers/pretraining_trainer_auto.py
+++ b/examples/auto_parallel/trainers/pretraining_trainer_auto.py
@@ -43,8 +43,6 @@ from paddleformers.trainer import AutoTrainingArguments
 from paddleformers.trainer.utils import add_start_docstrings
 from paddleformers.trainer.trainer_callback import PrinterCallback
 from paddleformers.trainer.trainer_utils import get_cosine_schedule_with_warmup
-from paddle.distributed import fleet
-from paddle.distributed.auto_parallel.pipelining.schedules import get_pipeline_schedule
 from typing import Any, Dict, Union
 import paddle.distributed as dist
 from .callbacks_auto import TensorBoardCallback
@@ -232,23 +230,23 @@ class AutoPreTrainingArguments(AutoTrainingArguments):
 
         self.max_gradient_accumulation_steps = self.gradient_accumulation_steps
 
-        if self.pipeline_parallel_degree > 1:
-            self.per_device_eval_batch_size = (
-                self.per_device_train_batch_size * self.gradient_accumulation_steps
-            )
-            logger.warn(
-                f"eval_batch_size set to {self.per_device_eval_batch_size} in Pipeline Parallel!"
-            )
-            user_defined_strategy = fleet.fleet._user_defined_strategy
-            user_defined_strategy.strategy.pipeline_configs.accumulate_steps = (
-                self.gradient_accumulation_steps
-            )
+        # if self.pipeline_parallel_degree > 1:
+        #     self.per_device_eval_batch_size = (
+        #         self.per_device_train_batch_size * self.gradient_accumulation_steps
+        #     )
+        #     logger.warn(
+        #         f"eval_batch_size set to {self.per_device_eval_batch_size} in Pipeline Parallel!"
+        #     )
+        #     user_defined_strategy = fleet.fleet._user_defined_strategy
+        #     user_defined_strategy.strategy.pipeline_configs.accumulate_steps = (
+        #         self.gradient_accumulation_steps
+        #     )
 
-            self.max_gradient_accumulation_steps = self.gradient_accumulation_steps
-            logger.info(f"fixing pp configs: {user_defined_strategy.pipeline_configs}")
-        else:
-            self.per_device_eval_batch_size = self.per_device_train_batch_size
-            logger.warn(f"eval_batch_size set to {self.per_device_eval_batch_size}")
+        #     self.max_gradient_accumulation_steps = self.gradient_accumulation_steps
+        #     logger.info(f"fixing pp configs: {user_defined_strategy.pipeline_configs}")
+        # else:
+        self.per_device_eval_batch_size = self.per_device_train_batch_size
+        logger.warn(f"eval_batch_size set to {self.per_device_eval_batch_size}")
 
 
 class AutoPretrainingTrainer(AutoTrainer):
@@ -281,22 +279,22 @@ class AutoPretrainingTrainer(AutoTrainer):
         self.model_numel = numel_tensor.item() // self.args.dataset_world_size
 
         self.pop_callback(PrinterCallback)
-        if self.args.pipeline_parallel_degree > 1:
-            if self.criterion is None:
-                self.criterion = self.model.criterion
-            self.pp_schedule = get_pipeline_schedule(
-                model,
-                self.args.gradient_accumulation_steps,
-                self.criterion,
-                self.args.pipeline_schedule_mode,
-                self.args.pipeline_parallel_degree,
-                self.comm_group_in_pp,
-            )
-            self.args.per_device_train_batch_size = (
-                self.args.per_device_train_batch_size
-                * self.args.gradient_accumulation_steps
-            )
-            self.args.gradient_accumulation_steps = 1
+        # if self.args.pipeline_parallel_degree > 1:
+        #     if self.criterion is None:
+        #         self.criterion = self.model.criterion
+        #     self.pp_schedule = get_pipeline_schedule(
+        #         model,
+        #         self.args.gradient_accumulation_steps,
+        #         self.criterion,
+        #         self.args.pipeline_schedule_mode,
+        #         self.args.pipeline_parallel_degree,
+        #         self.comm_group_in_pp,
+        #     )
+        #     self.args.per_device_train_batch_size = (
+        #         self.args.per_device_train_batch_size
+        #         * self.args.gradient_accumulation_steps
+        #     )
+        #     self.args.gradient_accumulation_steps = 1
 
     def compute_pipeline_loss(self, model, inputs, return_outputs=False):
         """
@@ -347,10 +345,10 @@ class AutoPretrainingTrainer(AutoTrainer):
     def dynamic_training(
         self, model: nn.Layer, inputs: Dict[str, Union[paddle.Tensor, Any]]
     ) -> paddle.Tensor:
-        if self.args.pipeline_parallel_degree > 1:
-            return self.dynamic_auto_parallel_pipeline_training(model, inputs)
-        else:
-            return super().dynamic_training(model, inputs)
+        # if self.args.pipeline_parallel_degree > 1:
+        #     return self.dynamic_auto_parallel_pipeline_training(model, inputs)
+        # else:
+        return super().dynamic_training(model, inputs)
 
     def autocast_smart_context_manager(self):
 


### PR DESCRIPTION
单卡组网+中层API版本自动并行实现
TODO：
1. moe cor_bias 部分由于绕过切多刀的d0 mesh实现存在input mesh不统一错误，需修复
2. PP逻辑仍需整理，目前仍在组网中保留了一部分PP逻辑（即PP与非PP组网不同），后续应统一使用中层API接口的PP实现来替换pipeline schedule的PP实现，并将组网彻底优化为单卡组网
3. PP通信部分目前仍使用pipeline schedule的实现，需要注释掉中层API的PP hook，后续统一替换为中层API实现
4. 两个layer_hook可以删除 不影响正确性 但删除后会触发中层API大量warning
5. 原组网部分多卡逻辑的代码目前只是注释，待完善上面的实现后删除