### PR TITLE
[AutoParallel] Fix save checkpoint bug

### DIFF
--- a/examples/auto_parallel/models/moe_layer.py
+++ b/examples/auto_parallel/models/moe_layer.py
@@ -68,7 +68,7 @@ class MoEStatics(nn.Layer):
                 len(config.moe_num_experts) if config.multimodel_experts else 1
             )
             p = self.create_parameter(
-                shape=[num_experts_groups, num_experts],
+                shape=[num_experts_groups * num_experts],
                 dtype="float32",
                 is_bias=True,
                 attr=paddle.ParamAttr(
@@ -470,7 +470,14 @@ class MOELayer(nn.Layer):
                 )
                 if "corr_bias" in inspect.signature(moe_gate_dispatch).parameters:
                     if self.use_correction_bias:
-                        compat_args = (self.moe_statics.e_score_correction_bias[0],)
+                        num_experts = (
+                            self.config.moe_num_experts[0]
+                            if self.config.multimodel_experts
+                            else self.config.moe_num_experts
+                        )
+                        compat_args = (
+                            self.moe_statics.e_score_correction_bias[:num_experts],
+                        )
                     else:
                         compat_args = (None,)
                 else:

--- a/examples/auto_parallel/trainers/callbacks/moe_correction_bias_adjust_callback.py
+++ b/examples/auto_parallel/trainers/callbacks/moe_correction_bias_adjust_callback.py
@@ -28,7 +28,6 @@ class MoECorrectionBiasAdjustCallback(TrainerCallback):
         self.use_sp = use_sp
 
     def on_optimizer_end(self, args, state, control, **kwargs):
-        # print("xxx ------- enter on_optimizer_end")
         model = kwargs["model"]
 
         usages = {}

--- a/examples/auto_parallel/trainers/callbacks/moe_correction_bias_adjust_callback.py
+++ b/examples/auto_parallel/trainers/callbacks/moe_correction_bias_adjust_callback.py
@@ -28,6 +28,7 @@ class MoECorrectionBiasAdjustCallback(TrainerCallback):
         self.use_sp = use_sp
 
     def on_optimizer_end(self, args, state, control, **kwargs):
+        # print("xxx ------- enter on_optimizer_end")
         model = kwargs["model"]
 
         usages = {}
@@ -75,7 +76,7 @@ class MoECorrectionBiasAdjustCallback(TrainerCallback):
                 with paddle.no_grad():
                     if layer.mlp.gate.weight.stop_gradient:
                         update_dict[layer.layer_idx][0, :] = 0
-                    biases[layer.layer_idx].add_(update_dict[layer.layer_idx])
+                    biases[layer.layer_idx].add_(update_dict[layer.layer_idx].flatten())
                     usages[layer.layer_idx].data.zero_()
 
         model.apply(update_bias)


### PR DESCRIPTION
MoEStatics 中参数 e_score_correction_bias 没有 mesh_process 信息，导致保存 ckpt 时报错
给 e_score_correction_bias 进行 shard_tensor 后会有 切2刀报错
这里选择将 e_score_correction_bias 初始化从 二维[num_experts_groups,  num_experts] 改为 一维 [num_experts_groups * num_experts]，绕过切两刀的问题，可以正常保存 ckpt 