### PR TITLE
[AutoParallel] fix bux moe_use_aux_free in use_intermediate_api

### DIFF
--- a/examples/auto_parallel/models/modeling.py
+++ b/examples/auto_parallel/models/modeling.py
@@ -1694,7 +1694,7 @@ class ErnieForCausalLM(ErniePretrainedModel):
                         dist.SequenceParallelBegin(),
                     ],
                     f"{prefix}ernie.layers.*.self_attn": dist.SequenceParallelDisable(),
-                    f"{prefix}ernie.ayers.*.self_attn.q_proj": dist.ColWiseParallel(),
+                    f"{prefix}ernie.layers.*.self_attn.q_proj": dist.ColWiseParallel(),
                     f"{prefix}ernie.layers.*.self_attn.k_proj": dist.ColWiseParallel(),
                     f"{prefix}ernie.layers.*.self_attn.v_proj": dist.ColWiseParallel(),
                     f"{prefix}ernie.layers.*.self_attn.o_proj": dist.RowWiseParallel(),

--- a/examples/auto_parallel/models/moe_layer.py
+++ b/examples/auto_parallel/models/moe_layer.py
@@ -476,7 +476,13 @@ class MOELayer(nn.Layer):
                 )
                 if "corr_bias" in inspect.signature(moe_gate_dispatch).parameters:
                     if self.use_correction_bias:
-                        compat_args = (self.moe_statics.e_score_correction_bias[0],)
+                        compat_args = (
+                            _reshard(
+                                self.moe_statics.e_score_correction_bias[0],
+                                get_flatten_mesh(get_mesh(self.ipp)),
+                                [dist.Replicate()],
+                            ),
+                        )
                     else:
                         compat_args = (None,)
                 else:
@@ -501,7 +507,15 @@ class MOELayer(nn.Layer):
                                 self.gate.experts_type_mask[i]
                             ].detach()
                     else:
-                        self.moe_statics.expert_usage[0] += dispatch_mask.detach()
+                        reshard_dispatch_mask = _reshard(
+                            dispatch_mask.detach(),
+                            get_mesh(self.ipp),
+                            [
+                                dist.Replicate()
+                                for _ in range(len(get_mesh(self.ipp).shape))
+                            ],
+                        )
+                        self.moe_statics.expert_usage[0] += reshard_dispatch_mask
                 dispatched_input.stop_gradient = False
                 combine_weights_unnorm.stop_gradient = False
                 dispatch_mask.stop_gradient = True

--- a/examples/auto_parallel/trainers/callbacks/moe_correction_bias_adjust_callback.py
+++ b/examples/auto_parallel/trainers/callbacks/moe_correction_bias_adjust_callback.py
@@ -57,25 +57,28 @@ class MoECorrectionBiasAdjustCallback(TrainerCallback):
         mp_group = hcg.get_model_parallel_group()
         dp_group = hcg.get_data_parallel_group()
         sd_group = hcg.get_sharding_parallel_group()
-        if self.use_sp and mp_group.nranks > 1:
-            dist.all_reduce(usages_tensor._local_value(), group=mp_group)
-        if dp_group.nranks > 1:
-            dist.all_reduce(usages_tensor._local_value(), group=dp_group)
-        if sd_group.nranks > 1:
-            dist.all_reduce(usages_tensor._local_value(), group=sd_group)
-        usages_mean = usages_tensor.mean(-1, keepdim=True)
-        update = paddle.sign(usages_mean - usages_tensor) * self.update_lr
-        update_dict = dict(zip(keys, update))
+        if usages_tensor._local_value() is not None:
+            if self.use_sp and mp_group.nranks > 1:
+                dist.all_reduce(usages_tensor._local_value(), group=mp_group)
+            if dp_group.nranks > 1:
+                dist.all_reduce(usages_tensor._local_value(), group=dp_group)
+            if sd_group.nranks > 1:
+                dist.all_reduce(usages_tensor._local_value(), group=sd_group)
+            usages_mean = usages_tensor.mean(-1, keepdim=True)
+            update = paddle.sign(usages_mean - usages_tensor) * self.update_lr
+            update_dict = dict(zip(keys, update))
 
-        def update_bias(layer):
-            nonlocal usages, biases
-            if isinstance(layer, self.model_class):
-                if not isinstance(layer.mlp, MOELayer):
-                    return
-                with paddle.no_grad():
-                    if layer.mlp.gate.weight.stop_gradient:
-                        update_dict[layer.layer_idx][0, :] = 0
-                    biases[layer.layer_idx].add_(update_dict[layer.layer_idx].flatten())
-                    usages[layer.layer_idx].data.zero_()
+            def update_bias(layer):
+                nonlocal usages, biases
+                if isinstance(layer, self.model_class):
+                    if not isinstance(layer.mlp, MOELayer):
+                        return
+                    with paddle.no_grad():
+                        if layer.mlp.gate.weight.stop_gradient:
+                            update_dict[layer.layer_idx][0, :] = 0
+                        biases[layer.layer_idx].add_(
+                            update_dict[layer.layer_idx].flatten()
+                        )
+                        usages[layer.layer_idx].data.zero_()
 
-        model.apply(update_bias)
+            model.apply(update_bias)


### PR DESCRIPTION
修复中层API中moe_use_aux_free无法开启的问题
- 问题背景：
1. 中层API会自动初始化所有模型_init_中的weight的mesh，cor_bias也是其中之一，但cor_bias被运算时所需要的mesh为切两刀版本mesh，与中层API所初始化的mesh不符合
2. 中层API会在每个机器上跑完整组网，因此会出现cor_bias为none的情况，此时不应触发call_back
- 解决方案：
1. forward中将cor_bias重新_reshard为切两刀版本mesh
2. 增加local_value 检查