### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.isort]
+profile = 'black'
+known_third_party = ["paddle"]
+skip = []
+
+[tool.black]
+line-length = 119
+target_version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310']
+exclude = []
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q "
+pythonpath = ["."]
+testpaths = [
+    "tests/gpu",
+    "tests/iluvatar_gpu",
+    "tests/npu",
+    "tests/xpu",
+]
+python_files = [
+    "test.py",
+    "test_*.py"
+]
+filterwarnings = [
+    "ignore::UserWarning",
+    'ignore::DeprecationWarning',
+]


### PR DESCRIPTION
解决这个pip版本的要求：
DEPRECATION: Legacy editable install of erniekit==0.0.0 from path_to_ERNIE (setup.py develop) is deprecated. pip 25.3 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457