### PR TITLE
bugfix(sft+function call)

### DIFF
--- a/ernie/dataset/finetuning.py
+++ b/ernie/dataset/finetuning.py
@@ -214,7 +214,7 @@ def process_fc(data, input_file):
             ex = Example(
                 request={"messages": message, "tools": tools_list},
                 system=system,
-                label=label,
+                label=[1],
                 is_system=is_system,
                 source=input_file,
                 is_function_call=True,
@@ -578,6 +578,9 @@ class SequenceDataset(IterableDataset):
 
         turn_index = len(encoded_messages) - 1
 
+        print('lrl debug ------------------------------')
+        print('len(encoded_messages) : ', len(encoded_messages))
+        print('len(example.label) : ', len(example.label))
         tokens = []
         loss_mask = []
         while turn_index >= 0:

--- a/ernie/dataset/finetuning.py
+++ b/ernie/dataset/finetuning.py
@@ -578,9 +578,6 @@ class SequenceDataset(IterableDataset):
 
         turn_index = len(encoded_messages) - 1
 
-        print('lrl debug ------------------------------')
-        print('len(encoded_messages) : ', len(encoded_messages))
-        print('len(example.label) : ', len(example.label))
         tokens = []
         loss_mask = []
         while turn_index >= 0:


### PR DESCRIPTION
在function call的sft训练过程中，我们通过控制输入label为[1,1,1]还是[0,0,1]来控制训所有轮还是只训最后一轮。

注意：
这里说的训所有轮是把【A，B，C，D】这样的对话拆成【A，B】、【A，B，C，D】这样的两个样本
第一个样本以【B】作为label，【A】作为输入；第二个样本以【D】作为label，【A，B，C】作为输入
每个样本都看成是单轮对话，所以yield example这里的label应该是写死为[1]，而不是用原始传入的label