### PR TITLE
domain-self-constraint cpt support.

### DIFF
--- a/examples/pre-training/ernie/pretrain.py
+++ b/examples/pre-training/ernie/pretrain.py
@@ -172,15 +172,17 @@ def create_pretrained_dataset(args):
     def _collate_data(data, stack_fn=Stack()):
         tokens_ = stack_fn([x["text"] for x in data])
         kl_logits_ = stack_fn([x["logits"] for x in data])
+        kl_ids_ = stack_fn([x["ids"] for x in data])
         CPT = ratio_maker([x["CPT"] for x in data])
 
         labels = tokens_[:, 1:]
         tokens = tokens_[:, :-1]
         kl_logits = kl_logits_[:, :-1]
+        kl_ids = kl_ids_[:, :-1]
 
         return {
             "input_ids": tokens,
-            "labels": [labels, kl_logits, CPT],
+            "labels": [labels, kl_logits, kl_ids, CPT],
         }
 
     return train_dataset, valid_dataset, test_dataset, _collate_data

--- a/examples/pre-training/ernie/pretrain.py
+++ b/examples/pre-training/ernie/pretrain.py
@@ -146,18 +146,30 @@ def create_pretrained_dataset(args):
         seed=args.seed,
         skip_warmup=True,
         data_cache_path=None,
+        self_constraint_cpt=args.self_constraint_cpt,
+        prob_nums=args.prob_nums,
     )
 
     def ratio_maker(CPT):
         """
-        input: [True, False, False, True]
-        output: {"kl_ratio": Tensor([0.5, 1, 1, 0.5]), "ce_ratio": Tensor([1, 0.5, 0.5, 1])}
+        Generates KL and CE ratio tensors based on a boolean input array.
+        Applies different ratios to positions where the input is True vs False.
+
+        Args:
+            CPT: List or tensor of boolean values indicating special positions
+                 Example input: [True, False, False, True]
+
+        Returns:
+            Tensor: Concatenated tensor containing KL ratios followed by CE ratios
+                    Example output structure (values depend on configuration):
+                    Tensor([0.5, 1, 1, 0.5, 1, 0.5, 0.5, 1])
+                    Where first 4 elements are KL ratios and last 4 are CE ratios
         """
         CPT = paddle.to_tensor(CPT, dtype="bool")
-        true_kl = 0.5
-        false_kl = 1
-        true_ce = 1
-        false_ce = 0.5
+        true_kl = args.cpt_kl_ratio
+        false_kl = args.pt_kl_ratio
+        true_ce = args.cpt_ce_ratio
+        false_ce = args.pt_ce_ratio
 
         kl_ratio = paddle.full_like(CPT, false_kl, dtype="float32")
         kl_ratio[CPT] = true_kl
@@ -171,14 +183,16 @@ def create_pretrained_dataset(args):
 
     def _collate_data(data, stack_fn=Stack()):
         tokens_ = stack_fn([x["text"] for x in data])
-        kl_logits_ = stack_fn([x["logits"] for x in data])
-        kl_ids_ = stack_fn([x["ids"] for x in data])
-        CPT = ratio_maker([x["CPT"] for x in data])
-
         labels = tokens_[:, 1:]
         tokens = tokens_[:, :-1]
-        kl_logits = kl_logits_[:, :-1]
-        kl_ids = kl_ids_[:, :-1]
+
+        kl_logits, kl_ids, CPT = None, None, None
+        if args.self_constraint_cpt:
+            kl_logits_ = stack_fn([x["logits"] for x in data])
+            kl_ids_ = stack_fn([x["ids"] for x in data])
+            CPT = ratio_maker([x["CPT"] for x in data])
+            kl_logits = kl_logits_[:, :-1]
+            kl_ids = kl_ids_[:, :-1]
 
         return {
             "input_ids": tokens,

--- a/examples/pre-training/ernie/pretrain.py
+++ b/examples/pre-training/ernie/pretrain.py
@@ -148,17 +148,39 @@ def create_pretrained_dataset(args):
         data_cache_path=None,
     )
 
+    def ratio_maker(CPT):
+        """
+        input: [True, False, False, True]
+        output: {"kl_ratio": Tensor([0.5, 1, 1, 0.5]), "ce_ratio": Tensor([1, 0.5, 0.5, 1])}
+        """
+        CPT = paddle.to_tensor(CPT, dtype="bool")
+        true_kl = 0.5
+        false_kl = 1
+        true_ce = 1
+        false_ce = 0.5
+
+        kl_ratio = paddle.full_like(CPT, false_kl, dtype="float32")
+        kl_ratio[CPT] = true_kl
+
+        ce_ratio = paddle.full_like(CPT, false_ce, dtype="float32")
+        ce_ratio[CPT] = true_ce
+
+        return {"kl_ratio": kl_ratio, "ce_ratio": ce_ratio}
+
     from paddleformers.data import Stack
 
     def _collate_data(data, stack_fn=Stack()):
         tokens_ = stack_fn([x["text"] for x in data])
+        kl_logits_ = stack_fn([x["logits"] for x in data])
+        CPT = ratio_maker([x["CPT"] for x in data])
 
         labels = tokens_[:, 1:]
         tokens = tokens_[:, :-1]
+        kl_logits = kl_logits_[:, :-1]
 
         return {
             "input_ids": tokens,
-            "labels": labels,
+            "labels": [labels, kl_logits, CPT],
         }
 
     return train_dataset, valid_dataset, test_dataset, _collate_data

--- a/examples/pre-training/ernie/pretrain.py
+++ b/examples/pre-training/ernie/pretrain.py
@@ -165,7 +165,7 @@ def create_pretrained_dataset(args):
         ce_ratio = paddle.full_like(CPT, false_ce, dtype="float32")
         ce_ratio[CPT] = true_ce
 
-        return {"kl_ratio": kl_ratio, "ce_ratio": ce_ratio}
+        return paddle.cat([kl_ratio, ce_ratio])
 
     from paddleformers.data import Stack
 

--- a/examples/pre-training/ernie/src/trainers/pretraining_trainer.py
+++ b/examples/pre-training/ernie/src/trainers/pretraining_trainer.py
@@ -192,6 +192,32 @@ class PreTrainingArguments(TrainingArguments):
             "help": "Pretrained tokenizer name or path if not the same as model_name"
         },
     )
+    self_constraint_cpt: Optional[bool] = field(
+        default=False,
+        metadata={"help": "whether to use self-constraint continual pre-training."},
+    )
+    prob_nums: int = field(
+        default=10,
+        metadata={
+            "help": "when self-constraint continual pre-train, retrieve prob_nums logprobs for kl loss."
+        },
+    )
+    cpt_kl_ratio: float = field(
+        default=0.5,
+        metadata={"help": "continual pre-training kl loss ratio."},
+    )
+    pt_kl_ratio: float = field(
+        default=1.0,
+        metadata={"help": "pre-training kl loss ratio."},
+    )
+    cpt_ce_ratio: float = field(
+        default=1.0,
+        metadata={"help": "continual pre-training ce loss ratio."},
+    )
+    pt_ce_ratio: float = field(
+        default=0.5,
+        metadata={"help": "pre-training ce loss ratio."},
+    )
     sequence_parallel: Optional[int] = field(
         default=0,
         metadata={},

--- a/examples/pre-training/models/ernie/modeling.py
+++ b/examples/pre-training/models/ernie/modeling.py
@@ -2233,8 +2233,6 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
         loss_ratio=None,
     ):
 
-        # print("kl_logits shape:", kl_logits.shape if kl_logits is not None else None)
-        # print("hid_logits shape:", prediction_scores.shape)
         if self.config.use_sparse_head_and_loss_fn:
             hidden_states, outlinear_weight, outlinear_bias = prediction_scores
 
@@ -2423,14 +2421,17 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                     degree=self.config.tensor_parallel_degree,
                     rank=self.config.tensor_parallel_rank,
                 )
-                print("Kl loss:", kl_loss.mean())
-                print("ce loss:", masked_lm_loss.mean())
+                kl_loss_log = kl_loss.mean()
+                ce_loss_log = masked_lm_loss.mean()
                 masked_lm_loss = (
                     loss_ratio[: loss_ratio.shape[0] // 2][:, None, None] * kl_loss
                     + loss_ratio[loss_ratio.shape[0] // 2 :][:, None, None]
                     * masked_lm_loss
                 )
-                print("kl_ce_loss:", masked_lm_loss.mean())
+                full_step_loss_log = masked_lm_loss.mean()
+                logger.info(
+                    f"[Micro Step]: KL Loss {kl_loss_log}, CE Loss {ce_loss_log}, Full Loss {full_step_loss_log}"
+                )
 
             lossmask = masked_lm_labels != self.ignored_index
             if (~lossmask).all():

--- a/examples/pre-training/models/ernie/modeling.py
+++ b/examples/pre-training/models/ernie/modeling.py
@@ -30,6 +30,7 @@ from models.sequence_parallel_utils import (
     AllGatherVarlenOp,
     ColumnSequenceParallelLinear,
     GatherOp,
+    AllGatherOp,
     RowSequenceParallelLinear,
     ScatterOp,
     mark_as_sequence_parallel_parameter,
@@ -72,7 +73,9 @@ NativeLinear = nn.Linear
 try:
     from paddle.nn.functional.flash_attention import flash_attention
 
-    logger.warning("Use flash attention in scaled-dot-product. Attention mask is deprecated")
+    logger.warning(
+        "Use flash attention in scaled-dot-product. Attention mask is deprecated"
+    )
 except (ImportError, ModuleNotFoundError):
     flash_attention = None
 
@@ -120,6 +123,121 @@ __all__ = [
 ]
 
 
+class DistributedSoftmaxOp(PyLayer):
+    """
+    分布式Softmax操作，支持模型并行
+    输入形状: [s/n, b, h]，n是模型并行度
+    输出形状: [s/n, b, h]
+    """
+
+    @staticmethod
+    def forward(ctx, x, axis=-1, mp_group=None):
+        """
+        前向传播
+        Args:
+            x: 输入张量 [s/n, b, h]
+            axis: softmax计算的轴
+            mp_group: 模型并行组
+        Returns:
+            softmax_output: softmax输出 [s/n, b, h]
+        """
+        # 保存参数用于反向传播
+        ctx.axis = axis
+        ctx.mp_group = mp_group
+
+        if mp_group is None:
+            hcg = fleet.get_hybrid_communicate_group()
+            ctx.mp_group = hcg.get_model_parallel_group()
+
+        # 1. 数值稳定性处理：减去最大值防止指数运算溢出
+        # 计算本地最大值
+        local_max = paddle.max(x, axis=axis, keepdim=True)
+
+        # 收集所有设备的最大值 - 使用AllGatherOp
+        # 注意：这里需要将最大值在模型并行组内收集
+        all_max = AllGatherOp.apply(local_max, axis=0, group=ctx.mp_group)
+
+        # 计算全局最大值
+        global_max = paddle.max(all_max, axis=0, keepdim=True)
+
+        # 减去全局最大值
+        x_stable = x - global_max
+
+        # 2. 计算指数
+        exp_x = paddle.exp(x_stable.cast("float32"))
+
+        local_sum_exp = paddle.sum(exp_x, axis=axis, keepdim=True)
+
+        sum_exp = mp_ops._mp_allreduce(
+            local_sum_exp,
+            group=mp_group,
+            use_calc_stream=True,
+            use_model_parallel=True,
+        )
+
+        # 4. 计算softmax概率
+        softmax_output = exp_x / sum_exp
+
+        # 保存中间结果用于反向传播
+        ctx.save_for_backward(softmax_output, sum_exp)
+
+        return softmax_output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """
+        反向传播
+        Args:
+            grad_output: 上游梯度 [s/n, b, h]
+        Returns:
+            grad_input: 输入梯度 [s/n, b, h]
+        """
+        # 恢复保存的张量
+        softmax_output, global_sum_exp = ctx.saved_tensor()
+        axis = ctx.axis
+        mp_group = ctx.mp_group
+
+        # softmax的梯度公式: dL/dx = softmax * (dL/dy - sum(dL/dy * softmax, axis=axis))
+
+        # 1. 计算 dL/dy * softmax
+        grad_softmax = grad_output * softmax_output
+
+        # 2. 计算 sum(dL/dy * softmax, axis=axis) 的本地部分
+        local_sum_grad = paddle.sum(grad_softmax, axis=axis, keepdim=True)
+
+        # 3. 使用AllGatherOp收集所有设备的局部梯度，然后求和得到全局梯度
+        all_sum_grad = AllGatherOp.apply(local_sum_grad, axis=0, group=mp_group)
+        global_sum_grad = paddle.sum(all_sum_grad, axis=0, keepdim=True)
+
+        # 4. 计算最终梯度
+        grad_input = softmax_output * (grad_output - global_sum_grad)
+
+        return grad_input
+
+
+def kl_divergence(p, q, eps: float = 1e-10, degree=-1, rank=-1):
+    """
+    D_KL(p||q) = sum(p * log(p/q))
+
+    Args:
+        p: policy logprobs [batch, seq_len, vocab // tp_degree]
+        q: ref logprobs [batch, seq_len, vocab]
+        eps: -
+    """
+
+    if p.shape[-1] != q.shape[-1]:
+        interval_per_rank = q.shape[-1] // degree
+        q = q[..., rank * interval_per_rank : (rank + 1) * interval_per_rank]
+    p = p + eps
+    q = q + eps
+
+    log_p = paddle.log(p)
+    log_q = paddle.log(q)
+    kl = p * (log_p - log_q)
+
+    return kl.mean(axis=-1, keepdim=True)
+
+
 def get_triangle_upper_mask(x, mask=None):
     if mask is not None:
         return mask
@@ -153,7 +271,9 @@ def gqa_qkv_split_func(
         q_list = paddle.split(q, tensor_parallel_degree, axis=-1)
         k_list = paddle.split(k, tensor_parallel_degree, axis=-1)
         v_list = paddle.split(v, tensor_parallel_degree, axis=-1)
-        ret = [paddle.concat([q, k, v], axis=-1) for q, k, v in zip(q_list, k_list, v_list)]
+        ret = [
+            paddle.concat([q, k, v], axis=-1) for q, k, v in zip(q_list, k_list, v_list)
+        ]
         return ret
     else:
         q = paddle.split(q, tensor_parallel_degree, axis=-1)[tensor_parallel_rank]
@@ -205,7 +325,9 @@ def parallel_matmul(
                 logits += bias
         else:
             if fuse_linear:
-                logits = paddle.incubate.nn.functional.fused_linear(input_parallel, y, bias)
+                logits = paddle.incubate.nn.functional.fused_linear(
+                    input_parallel, y, bias
+                )
             else:
                 logits = F.linear(input_parallel, y, bias)
 
@@ -216,7 +338,9 @@ def parallel_matmul(
 
     else:
         if fuse_linear:
-            logits = paddle.incubate.nn.functional.fused_linear(x, y, bias, transpose_weight=transpose_y)
+            logits = paddle.incubate.nn.functional.fused_linear(
+                x, y, bias, transpose_weight=transpose_y
+            )
         else:
             logits = paddle.matmul(x, y, transpose_y=transpose_y)
             if bias is not None:
@@ -224,7 +348,9 @@ def parallel_matmul(
         return logits
 
 
-def calc_lm_head_logits(config, hidden_states, weight, bias, tensor_parallel_output=None, training=True):
+def calc_lm_head_logits(
+    config, hidden_states, weight, bias, tensor_parallel_output=None, training=True
+):
     if config.sequence_parallel:
         if config.use_sparse_head_and_loss_fn:
             pass
@@ -233,10 +359,16 @@ def calc_lm_head_logits(config, hidden_states, weight, bias, tensor_parallel_out
             if lm_head_use_gather:
                 hidden_states = GatherOp.apply(hidden_states)
             if not config.using_dynamic_sequence_length:
-                hidden_states = hidden_states.reshape([-1, config.seqlen, hidden_states.shape[-1]])
+                hidden_states = hidden_states.reshape(
+                    [-1, config.seqlen, hidden_states.shape[-1]]
+                )
             else:
-                assert config.micro_batch_size, "micro_batch_size should be set when using dygramic sequence length."
-                hidden_states = hidden_states.reshape([config.micro_batch_size, -1, hidden_states.shape[-1]])
+                assert (
+                    config.micro_batch_size
+                ), "micro_batch_size should be set when using dygramic sequence length."
+                hidden_states = hidden_states.reshape(
+                    [config.micro_batch_size, -1, hidden_states.shape[-1]]
+                )
 
     if tensor_parallel_output is None:
         tensor_parallel_output = config.tensor_parallel_output
@@ -277,7 +409,9 @@ def masked_fill(x, mask, value):
     return paddle.where(mask, y, x)
 
 
-def mem_eff_attn(query, key, value, pack_offset, drop_prob=0.0, dtype=paddle.bfloat16, training=True):
+def mem_eff_attn(
+    query, key, value, pack_offset, drop_prob=0.0, dtype=paddle.bfloat16, training=True
+):
     pack_offset = pack_offset.numpy()
     shape = pack_offset.shape
     assert len(shape) == 2, len(shape)
@@ -300,7 +434,9 @@ def mem_eff_attn(query, key, value, pack_offset, drop_prob=0.0, dtype=paddle.bfl
         return x.astype(dtype) if x.dtype != dtype else x
 
     if len(seqlens) == 1:
-        out, _ = flash_attention(query, key, value, drop_prob, causal=True, training=training)
+        out, _ = flash_attention(
+            query, key, value, drop_prob, causal=True, training=training
+        )
     else:
         mask = BlockDiagonalCausalMask.from_seqlens(seqlens)
         out = memory_efficient_attention(
@@ -326,7 +462,9 @@ def inbatch_pack_offset_to_attn_mask_start_row_indices(inbatch_pack_offset):
         row_start_indices = np.repeat(cumsum_item[1:], record_lens)
         attn_mask_row_start_indices.append(row_start_indices[None, None, ...])
     attn_mask_row_start_indices = np.concatenate(attn_mask_row_start_indices, axis=0)
-    return paddle.to_tensor(attn_mask_row_start_indices, dtype=paddle.int32), int(min_start_row)
+    return paddle.to_tensor(attn_mask_row_start_indices, dtype=paddle.int32), int(
+        min_start_row
+    )
 
 
 def scaled_dot_product_attention(
@@ -360,14 +498,20 @@ def scaled_dot_product_attention(
 
     can_use_fa = config.use_flash_attn and flash_attention is not None
     can_use_fa_sparse_mask = (
-        config.use_mem_eff_attn and inbatch_pack_offset is not None and flashmask_attention is not None
+        config.use_mem_eff_attn
+        and inbatch_pack_offset is not None
+        and flashmask_attention is not None
     )
 
     if not can_use_fa and not can_use_fa_sparse_mask:
         if query_states.shape[-2] != key_states.shape[-2]:
-            key_states = key_states.repeat_interleave(num_heads // num_key_value_heads, axis=-2)
+            key_states = key_states.repeat_interleave(
+                num_heads // num_key_value_heads, axis=-2
+            )
         if query_states.shape[-2] != value_states.shape[-2]:
-            value_states = value_states.repeat_interleave(num_heads // num_key_value_heads, axis=-2)
+            value_states = value_states.repeat_interleave(
+                num_heads // num_key_value_heads, axis=-2
+            )
 
     if can_use_fa:
         assert not (config.use_mem_eff_attn and inbatch_pack_offset is not None)
@@ -384,7 +528,9 @@ def scaled_dot_product_attention(
         return attn_output, attn_weights
     else:
 
-        query_states = paddle.transpose(query_states, [0, 2, 1, 3]) / math.sqrt(head_dim)
+        query_states = paddle.transpose(query_states, [0, 2, 1, 3]) / math.sqrt(
+            head_dim
+        )
         key_states = paddle.transpose(key_states, [0, 2, 1, 3])
         value_states = paddle.transpose(value_states, [0, 2, 1, 3])
 
@@ -408,14 +554,20 @@ def scaled_dot_product_attention(
             attn_weights = attention_mask + attn_weights
             attn_weights = paddle.maximum(
                 attn_weights,
-                paddle.to_tensor(float(finfo(query_states.dtype).min), dtype=query_states.dtype),
+                paddle.to_tensor(
+                    float(finfo(query_states.dtype).min), dtype=query_states.dtype
+                ),
             )
 
             if paddle.in_dynamic_mode():
                 with paddle.amp.auto_cast(False):
-                    attn_weights = F.softmax(attn_weights, axis=-1, dtype="float32").astype(query_states.dtype)
+                    attn_weights = F.softmax(
+                        attn_weights, axis=-1, dtype="float32"
+                    ).astype(query_states.dtype)
             else:
-                attn_weights = F.softmax(attn_weights, axis=-1, dtype="float32").astype(query_states.dtype)
+                attn_weights = F.softmax(attn_weights, axis=-1, dtype="float32").astype(
+                    query_states.dtype
+                )
         else:
             attn_weights = attn_weights.cast(paddle.float32)
             attention_mask = attention_mask.cast(paddle.float32)
@@ -453,12 +605,18 @@ def _make_causal_mask(input_ids_shape, past_key_values_length, dtype):
     mask = paddle.full((target_length, target_length), float(finfo(dtype).min))
 
     mask_cond = paddle.arange(mask.shape[-1])
-    mask = masked_fill(mask, mask_cond < (mask_cond + 1).reshape([mask.shape[-1], 1]), 0)
+    mask = masked_fill(
+        mask, mask_cond < (mask_cond + 1).reshape([mask.shape[-1], 1]), 0
+    )
 
     if past_key_values_length > 0:
-        mask = paddle.concat([paddle.zeros([target_length, past_key_values_length]), mask], axis=-1)
+        mask = paddle.concat(
+            [paddle.zeros([target_length, past_key_values_length]), mask], axis=-1
+        )
 
-    return mask[None, None, :, :].expand([batch_size, 1, target_length, target_length + past_key_values_length])
+    return mask[None, None, :, :].expand(
+        [batch_size, 1, target_length, target_length + past_key_values_length]
+    )
 
 
 def _expand_mask(mask, dtype, tgt_length):
@@ -470,10 +628,14 @@ def _expand_mask(mask, dtype, tgt_length):
         batch_size, src_length = mask.shape[0], mask.shape[-1]
         tgt_length = tgt_length if tgt_length is not None else src_length
 
-        expanded_mask = mask[:, None, None, :].expand([batch_size, 1, tgt_length, src_length])
+        expanded_mask = mask[:, None, None, :].expand(
+            [batch_size, 1, tgt_length, src_length]
+        )
 
     inverted_mask = 1.0 - expanded_mask
-    return masked_fill(inverted_mask, inverted_mask.cast("bool"), float(finfo(dtype).min))
+    return masked_fill(
+        inverted_mask, inverted_mask.cast("bool"), float(finfo(dtype).min)
+    )
 
 
 class FusedDropoutImpl(nn.Layer):
@@ -510,14 +672,20 @@ class RMSNorm(nn.Layer):
 
     def forward(self, hidden_states):
         if self.config.fuse_rms_norm:
-            return fused_rms_norm_ext(hidden_states, self.weight, self.variance_epsilon)[0]
+            return fused_rms_norm_ext(
+                hidden_states, self.weight, self.variance_epsilon
+            )[0]
         if paddle.in_dynamic_mode():
             with paddle.amp.auto_cast(False):
                 variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
-                hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+                hidden_states = (
+                    paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+                )
         else:
             variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
-            hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+            hidden_states = (
+                paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+            )
 
         if self.weight.dtype in [paddle.float16, paddle.bfloat16]:
             hidden_states = paddle.cast(hidden_states, self.weight.dtype)
@@ -529,7 +697,9 @@ class RotaryEmbedding(nn.Layer):
         super().__init__()
         self.base = base
         self.max_position_embeddings = max_position_embeddings
-        inv_freq = 1.0 / (base ** (paddle.cast(paddle.arange(0, dim, 2), dtype="float32") / dim))
+        inv_freq = 1.0 / (
+            base ** (paddle.cast(paddle.arange(0, dim, 2), dtype="float32") / dim)
+        )
 
         t = paddle.arange(max_position_embeddings, dtype="float32")
         freqs = paddle.einsum("i,j->ij", t, inv_freq.cast("float32"))
@@ -567,8 +737,12 @@ class RotaryEmbedding(nn.Layer):
         cos = cos[:, offset : q.shape[1] + offset, None, :]
         sin = sin[:, offset : q.shape[1] + offset, None, :]
 
-        q_embed = paddle.add(paddle.multiply(q, cos), paddle.multiply(cls.rotate_half(q), sin))
-        k_embed = paddle.add(paddle.multiply(k, cos), paddle.multiply(cls.rotate_half(k), sin))
+        q_embed = paddle.add(
+            paddle.multiply(q, cos), paddle.multiply(cls.rotate_half(q), sin)
+        )
+        k_embed = paddle.add(
+            paddle.multiply(k, cos), paddle.multiply(cls.rotate_half(k), sin)
+        )
         q_embed = q_embed.astype(q.dtype)
         k_embed = k_embed.astype(k.dtype)
         return q_embed, k_embed
@@ -592,8 +766,12 @@ class RopeEmbeddingLegacy(nn.Layer):
         else:
             position_ids = position_ids / self.compression_ratio
             seq_length = position_ids.shape[-1]
-            sinusoid_inp = position_ids.unsqueeze(-1).astype("float32") * indices.unsqueeze(0)
-        pos_emb = paddle.concat([paddle.sin(sinusoid_inp), paddle.cos(sinusoid_inp)], axis=-1)
+            sinusoid_inp = position_ids.unsqueeze(-1).astype(
+                "float32"
+            ) * indices.unsqueeze(0)
+        pos_emb = paddle.concat(
+            [paddle.sin(sinusoid_inp), paddle.cos(sinusoid_inp)], axis=-1
+        )
         pos_emb = paddle.reshape(pos_emb, (-1, 1, seq_length, self.head_dim))
         pos_emb.stop_gradient = True
         return pos_emb
@@ -642,7 +820,9 @@ class RopeEmbeddingLegacy(nn.Layer):
             :,
             1 : self.head_dim // 2 - self.freq_allocation : 2,
         ]
-        sin_hw = paddle.stack([sin_h, sin_w], axis=-1).reshape(sin_h.shape[:-1] + [sin_h.shape[-1] * 2])
+        sin_hw = paddle.stack([sin_h, sin_w], axis=-1).reshape(
+            sin_h.shape[:-1] + [sin_h.shape[-1] * 2]
+        )
         sin_thw = paddle.concat([sin_hw, sin_t], axis=-1)
 
         cos_t = cos[batch_indices, position_ids[..., 0], :, -self.freq_allocation :]
@@ -658,7 +838,9 @@ class RopeEmbeddingLegacy(nn.Layer):
             :,
             1 : self.head_dim // 2 - self.freq_allocation : 2,
         ]
-        cos_hw = paddle.stack([cos_h, cos_w], axis=-1).reshape(cos_h.shape[:-1] + [cos_h.shape[-1] * 2])
+        cos_hw = paddle.stack([cos_h, cos_w], axis=-1).reshape(
+            cos_h.shape[:-1] + [cos_h.shape[-1] * 2]
+        )
         cos_thw = paddle.concat([cos_hw, cos_t], axis=-1)
 
         sin_pos = paddle.reshape(
@@ -690,12 +872,18 @@ class RopeEmbeddingLegacy(nn.Layer):
 
     def forward_single(self, position_ids):
         batch_size, seq_length = position_ids.shape[:2]
-        rope_emb = paddle.zeros((2, batch_size, seq_length, 1, self.head_dim), dtype="float32")
-        inv_freq = self.base ** (-paddle.arange(0, self.head_dim, 2, dtype="float32") / self.head_dim)
+        rope_emb = paddle.zeros(
+            (2, batch_size, seq_length, 1, self.head_dim), dtype="float32"
+        )
+        inv_freq = self.base ** (
+            -paddle.arange(0, self.head_dim, 2, dtype="float32") / self.head_dim
+        )
         position_ids = position_ids.cast("float32")
         position_ids = position_ids / self.compression_ratio
         freqs = paddle.einsum("ij,k->ijk", position_ids.cast("float32"), inv_freq)
-        emb = paddle.stack([freqs, freqs], axis=-1).reshape((batch_size, seq_length, self.head_dim))
+        emb = paddle.stack([freqs, freqs], axis=-1).reshape(
+            (batch_size, seq_length, self.head_dim)
+        )
         emb = paddle.unsqueeze(emb, 2)
 
         rope_emb[0] = paddle.cos(emb)
@@ -720,16 +908,29 @@ class ErnieMLP(nn.Layer):
         self.fuse_ffn = config.fuse_attn_ffn
 
         if config.tensor_parallel_degree > 1:
-            ColumnLN = ColumnSequenceParallelLinear if config.sequence_parallel else ColumnParallelLinear
-            RowLN = RowSequenceParallelLinear if config.sequence_parallel else RowParallelLinear
+            ColumnLN = (
+                ColumnSequenceParallelLinear
+                if config.sequence_parallel
+                else ColumnParallelLinear
+            )
+            RowLN = (
+                RowSequenceParallelLinear
+                if config.sequence_parallel
+                else RowParallelLinear
+            )
 
             column_ln_configs = (
-                {"use_rr": config.use_recompute and config.skip_recompute_ops.get("mlp_column_ln", False)}
+                {
+                    "use_rr": config.use_recompute
+                    and config.skip_recompute_ops.get("mlp_column_ln", False)
+                }
                 if config.sequence_parallel and get_env_device() == "gpu"
                 else {}
             )
             if config.sequence_parallel and get_env_device() == "gpu":
-                column_ln_configs["use_tpsp_comm_overlap"] = config.use_tpsp_comm_overlap
+                column_ln_configs["use_tpsp_comm_overlap"] = (
+                    config.use_tpsp_comm_overlap
+                )
             if config.fuse_attn_ffn:
                 self.up_gate_proj = ColumnLN(
                     self.hidden_size,
@@ -757,7 +958,9 @@ class ErnieMLP(nn.Layer):
                     **column_ln_configs,
                 )
         else:
-            LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            LinearFN = (
+                paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            )
             if config.fuse_attn_ffn:
                 self.up_gate_proj = LinearFN(
                     self.hidden_size,
@@ -765,12 +968,19 @@ class ErnieMLP(nn.Layer):
                     bias_attr=config.use_bias,
                 )
             else:
-                self.gate_proj = LinearFN(self.hidden_size, self.intermediate_size, bias_attr=config.use_bias)
-                self.up_proj = LinearFN(self.hidden_size, self.intermediate_size, bias_attr=config.use_bias)
+                self.gate_proj = LinearFN(
+                    self.hidden_size, self.intermediate_size, bias_attr=config.use_bias
+                )
+                self.up_proj = LinearFN(
+                    self.hidden_size, self.intermediate_size, bias_attr=config.use_bias
+                )
 
         if config.tensor_parallel_degree > 1:
             row_ln_configs = (
-                {"use_rr": config.use_recompute and config.skip_recompute_ops.get("mlp_row_ln", False)}
+                {
+                    "use_rr": config.use_recompute
+                    and config.skip_recompute_ops.get("mlp_row_ln", False)
+                }
                 if config.sequence_parallel and get_env_device() == "gpu"
                 else {}
             )
@@ -785,8 +995,12 @@ class ErnieMLP(nn.Layer):
                 **row_ln_configs,
             )
         else:
-            LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
-            self.down_proj = LinearFN(self.intermediate_size, self.hidden_size, bias_attr=config.use_bias)
+            LinearFN = (
+                paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            )
+            self.down_proj = LinearFN(
+                self.intermediate_size, self.hidden_size, bias_attr=config.use_bias
+            )
 
         self.fuse_swiglu = config.fuse_swiglu
         if self.fuse_swiglu:
@@ -799,7 +1013,9 @@ class ErnieMLP(nn.Layer):
             and self.config.use_fp8_mlp
             and not self.config.use_bias
         ):
-            return MemEfficientFp8FusedMlpFunc.apply(x, self.up_gate_proj.weight, self.down_proj.weight)
+            return MemEfficientFp8FusedMlpFunc.apply(
+                x, self.up_gate_proj.weight, self.down_proj.weight
+            )
 
         if self.fuse_swiglu:
             if self.fuse_ffn:
@@ -844,15 +1060,24 @@ class ErnieAttention(nn.Layer):
         self.fuse_attn = config.fuse_attn_ffn
         self.use_recompute_attn = config.use_recompute_attn
         logger.info(f"using recompute attn={self.use_recompute_attn}")
-        self.is_gqa = config.num_key_value_heads is not None and config.num_key_value_heads != self.num_heads
+        self.is_gqa = (
+            config.num_key_value_heads is not None
+            and config.num_key_value_heads != self.num_heads
+        )
         if config.fuse_rope:
             assert fused_rope is not None, "fused_rope is not supported"
         self.fuse_rope = config.fuse_rope
         self.rope_3d = config.rope_3d
         if self.rope_3d:
-            assert not self.fuse_rope, "does not support fuse rope when rope_3d is on for now."
-            assert not config.rope_reorder, "does not support rope_reorder when rope_3d is on for now."
-            assert config.freq_allocation is not None, "freq_allocation must be provided if rope_3d is on."
+            assert (
+                not self.fuse_rope
+            ), "does not support fuse rope when rope_3d is on for now."
+            assert (
+                not config.rope_reorder
+            ), "does not support rope_reorder when rope_3d is on for now."
+            assert (
+                config.freq_allocation is not None
+            ), "freq_allocation must be provided if rope_3d is on."
 
         if config.tensor_parallel_degree > 1:
             assert (
@@ -863,9 +1088,13 @@ class ErnieAttention(nn.Layer):
                 assert (
                     self.num_key_value_heads % config.tensor_parallel_degree == 0
                 ), f"num_heads: {self.num_key_value_heads}, tensor_parallel_degree: {config.tensor_parallel_degree}"
-                self.num_key_value_heads = self.num_key_value_heads // config.tensor_parallel_degree
+                self.num_key_value_heads = (
+                    self.num_key_value_heads // config.tensor_parallel_degree
+                )
         if self.is_gqa:
-            logger.info(f"use GQA - num_heads: {self.num_heads}- num_key_value_heads: {self.num_key_value_heads}")
+            logger.info(
+                f"use GQA - num_heads: {self.num_heads}- num_key_value_heads: {self.num_key_value_heads}"
+            )
             assert (
                 self.num_heads % self.num_key_value_heads == 0
             ), f"num_heads: {self.num_heads}, num_key_value_heads: {self.num_key_value_heads}"
@@ -875,15 +1104,28 @@ class ErnieAttention(nn.Layer):
             q_hidden_size = kv_hidden_size = self.head_dim * config.num_attention_heads
 
         if config.tensor_parallel_degree > 1:
-            ColumnLN = ColumnSequenceParallelLinear if config.sequence_parallel else ColumnParallelLinear
-            RowLN = RowSequenceParallelLinear if config.sequence_parallel else RowParallelLinear
+            ColumnLN = (
+                ColumnSequenceParallelLinear
+                if config.sequence_parallel
+                else ColumnParallelLinear
+            )
+            RowLN = (
+                RowSequenceParallelLinear
+                if config.sequence_parallel
+                else RowParallelLinear
+            )
             column_ln_configs = (
-                {"use_rr": config.use_recompute and config.skip_recompute_ops.get("attention_column_ln", False)}
+                {
+                    "use_rr": config.use_recompute
+                    and config.skip_recompute_ops.get("attention_column_ln", False)
+                }
                 if config.sequence_parallel and get_env_device() == "gpu"
                 else {}
             )
             if config.sequence_parallel and get_env_device() == "gpu":
-                column_ln_configs["use_tpsp_comm_overlap"] = config.use_tpsp_comm_overlap
+                column_ln_configs["use_tpsp_comm_overlap"] = (
+                    config.use_tpsp_comm_overlap
+                )
 
             if config.fuse_attn_ffn:
                 self.qkv_proj = ColumnLN(
@@ -920,7 +1162,9 @@ class ErnieAttention(nn.Layer):
                     **column_ln_configs,
                 )
         else:
-            LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            LinearFN = (
+                paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            )
             if config.fuse_attn_ffn:
                 self.qkv_proj = LinearFN(
                     self.hidden_size,
@@ -946,7 +1190,10 @@ class ErnieAttention(nn.Layer):
 
         if config.tensor_parallel_degree > 1:
             row_ln_configs = (
-                {"use_rr": config.use_recompute and config.skip_recompute_ops.get("attention_row_ln", False)}
+                {
+                    "use_rr": config.use_recompute
+                    and config.skip_recompute_ops.get("attention_row_ln", False)
+                }
                 if config.sequence_parallel and get_env_device() == "gpu"
                 else {}
             )
@@ -962,7 +1209,9 @@ class ErnieAttention(nn.Layer):
                 **row_ln_configs,
             )
         else:
-            LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            LinearFN = (
+                paddle.incubate.nn.FusedLinear if config.fuse_linear else NativeLinear
+            )
             self.o_proj = LinearFN(
                 q_hidden_size,
                 self.hidden_size,
@@ -1004,7 +1253,11 @@ class ErnieAttention(nn.Layer):
     ) -> Tuple[paddle.Tensor, Optional[paddle.Tensor], Optional[Tuple[paddle.Tensor]]]:
         if self.config.sequence_parallel:
             if not self.config.using_dynamic_sequence_length:
-                bsz = hidden_states.shape[0] * self.config.tensor_parallel_degree // self.config.seqlen
+                bsz = (
+                    hidden_states.shape[0]
+                    * self.config.tensor_parallel_degree
+                    // self.config.seqlen
+                )
                 q_len = self.config.seqlen
             else:
                 assert (
@@ -1012,7 +1265,9 @@ class ErnieAttention(nn.Layer):
                 ), "micro_batch_size should be set when using dygramic sequence length."
 
                 bsz = self.config.micro_batch_size
-                q_len = hidden_states.shape[0] * self.config.tensor_parallel_degree // bsz
+                q_len = (
+                    hidden_states.shape[0] * self.config.tensor_parallel_degree // bsz
+                )
         else:
             bsz, q_len, _ = hidden_states.shape
         query_states = key_states = value_states = mix_layer = None
@@ -1030,9 +1285,13 @@ class ErnieAttention(nn.Layer):
                 )
                 mix_layer = None
             else:
-                mix_layer = mix_layer.reshape([bsz, q_len, self.num_heads, 3 * self.head_dim])
+                mix_layer = mix_layer.reshape(
+                    [bsz, q_len, self.num_heads, 3 * self.head_dim]
+                )
         else:
-            query_states = self.q_proj(hidden_states).reshape(shape=[bsz, q_len, self.num_heads, self.head_dim])
+            query_states = self.q_proj(hidden_states).reshape(
+                shape=[bsz, q_len, self.num_heads, self.head_dim]
+            )
             key_states = self.k_proj(hidden_states).reshape(
                 shape=[
                     bsz,
@@ -1109,7 +1368,9 @@ class ErnieAttention(nn.Layer):
 
         if self.rope_3d:
             assert position_ids is not None, "rope3d requires pos-id"
-        kv_seq_len = key_states.shape[-3] if not self.rope_3d else position_ids.max() + 1
+        kv_seq_len = (
+            key_states.shape[-3] if not self.rope_3d else position_ids.max() + 1
+        )
         offset = 0
         if past_key_value is not None:
             if not self.rope_3d:
@@ -1134,10 +1395,14 @@ class ErnieAttention(nn.Layer):
         else:
             if offset > 0 or position_ids is not None or not self.fuse_rope:
                 if not self.rope_3d:
-                    cos_sin = self.rotary_emb(kv_seq_len, position_ids).transpose([0, 2, 1, 3])
+                    cos_sin = self.rotary_emb(kv_seq_len, position_ids).transpose(
+                        [0, 2, 1, 3]
+                    )
                     if offset > 0 and position_ids is None:
                         cos_sin = cos_sin[:, offset:]
-                    query_states, key_states = self.rotary_emb.apply_rotary(cos_sin, query_states, key_states)
+                    query_states, key_states = self.rotary_emb.apply_rotary(
+                        cos_sin, query_states, key_states
+                    )
                 else:
                     cos_sin = self.rotary_emb(kv_seq_len).transpose([0, 2, 1, 3])
 
@@ -1152,8 +1417,12 @@ class ErnieAttention(nn.Layer):
                 bsz, q_len, num_heads, head_dim = query_states.shape
                 _, kv_seq_len, num_key_value_heads, _ = key_states.shape
                 if num_heads != num_key_value_heads:
-                    query_states, _, _ = fused_rope(query_states, None, None, rotary_emb_base=self.config.rope_theta)
-                    key_states, _, _ = fused_rope(key_states, None, None, rotary_emb_base=self.config.rope_theta)
+                    query_states, _, _ = fused_rope(
+                        query_states, None, None, rotary_emb_base=self.config.rope_theta
+                    )
+                    key_states, _, _ = fused_rope(
+                        key_states, None, None, rotary_emb_base=self.config.rope_theta
+                    )
                 else:
                     query_states, key_states, _ = fused_rope(
                         query_states,
@@ -1199,8 +1468,12 @@ class ErnieDecoderLayer(nn.Layer):
 
         self.input_layernorm = Norm(config)
         self.post_attention_layernorm = Norm(config)
-        self.residual_add1 = FusedDropoutImpl(config.hidden_dropout_prob, mode="upscale_in_train")
-        self.residual_add2 = FusedDropoutImpl(config.hidden_dropout_prob, mode="upscale_in_train")
+        self.residual_add1 = FusedDropoutImpl(
+            config.hidden_dropout_prob, mode="upscale_in_train"
+        )
+        self.residual_add2 = FusedDropoutImpl(
+            config.hidden_dropout_prob, mode="upscale_in_train"
+        )
         self.config = config
 
     def forward(
@@ -1226,8 +1499,13 @@ class ErnieDecoderLayer(nn.Layer):
             inbatch_pack_offset=inbatch_pack_offset,
         )
 
-        if self.config.tensor_parallel_degree > 1 and self.config.hidden_dropout_prob > 0.0:
-            current_seed = "local_seed" if self.config.sequence_parallel else "global_seed"
+        if (
+            self.config.tensor_parallel_degree > 1
+            and self.config.hidden_dropout_prob > 0.0
+        ):
+            current_seed = (
+                "local_seed" if self.config.sequence_parallel else "global_seed"
+            )
             with get_rng_state_tracker().rng_state(current_seed):
                 hidden_states = self.residual_add1(hidden_states, residual)
         else:
@@ -1237,8 +1515,13 @@ class ErnieDecoderLayer(nn.Layer):
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
 
-        if self.config.tensor_parallel_degree > 1 and self.config.hidden_dropout_prob > 0.0:
-            current_seed = "local_seed" if self.config.sequence_parallel else "global_seed"
+        if (
+            self.config.tensor_parallel_degree > 1
+            and self.config.hidden_dropout_prob > 0.0
+        ):
+            current_seed = (
+                "local_seed" if self.config.sequence_parallel else "global_seed"
+            )
             with get_rng_state_tracker().rng_state(current_seed):
                 hidden_states = self.residual_add2(hidden_states, residual)
         else:
@@ -1270,7 +1553,9 @@ class ErniePretrainedModel(PretrainedModel):
             ["norm.weight"],
         ]
         for layer_index in range(
-            config.num_hidden_layers if not config.remove_tail_layer else config.num_hidden_layers - 1
+            config.num_hidden_layers
+            if not config.remove_tail_layer
+            else config.num_hidden_layers - 1
         ):
             if config.fuse_attn_ffn:
                 layer_mappings = [
@@ -1332,7 +1617,10 @@ class ErniePretrainedModel(PretrainedModel):
                 mapping[1] = "ernie." + mapping[1]
             model_mappings.append(["lm_head.weight", "lm_head.weight", "transpose"])
 
-        mappings = [StateDictNameMapping(*mapping, index=index) for index, mapping in enumerate(model_mappings)]
+        mappings = [
+            StateDictNameMapping(*mapping, index=index)
+            for index, mapping in enumerate(model_mappings)
+        ]
         return mappings
 
     @classmethod
@@ -1347,7 +1635,10 @@ class ErniePretrainedModel(PretrainedModel):
             num_attention_heads=config.num_attention_heads,
         )
 
-        if config.num_key_value_heads is not None and config.num_key_value_heads != config.num_attention_heads:
+        if (
+            config.num_key_value_heads is not None
+            and config.num_key_value_heads != config.num_attention_heads
+        ):
             if is_split:
                 qkv_fn = partial(
                     gqa_qkv_split_func,
@@ -1372,8 +1663,12 @@ class ErniePretrainedModel(PretrainedModel):
             if config.fuse_attn_ffn:
                 base_actions = {
                     "layers.0.self_attn.qkv_proj.weight": qkv_fn,
-                    "layers.0.mlp.up_gate_proj.weight": partial(fn, is_column=True, is_naive_2fuse=True),
-                    "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                    "layers.0.mlp.up_gate_proj.weight": partial(
+                        fn, is_column=True, is_naive_2fuse=True
+                    ),
+                    "lm_head.weight": partial(
+                        fn, is_column=not config.tie_word_embeddings
+                    ),
                     "embed_tokens.weight": partial(fn, is_column=False),
                     "layers.0.self_attn.o_proj.weight": partial(fn, is_column=False),
                     "layers.0.mlp.down_proj.weight": partial(fn, is_column=False),
@@ -1382,7 +1677,9 @@ class ErniePretrainedModel(PretrainedModel):
                     base_actions.update(
                         {
                             "layers.0.self_attn.qkv_proj.bias": qkv_fn,
-                            "layers.0.mlp.up_gate_proj.bias": partial(fn, is_column=True, is_naive_2fuse=True),
+                            "layers.0.mlp.up_gate_proj.bias": partial(
+                                fn, is_column=True, is_naive_2fuse=True
+                            ),
                             "lm_head.bias": partial(fn, is_column=True),
                         }
                     )
@@ -1393,7 +1690,9 @@ class ErniePretrainedModel(PretrainedModel):
                     "layers.0.self_attn.v_proj.weight": partial(fn, is_column=True),
                     "layers.0.mlp.gate_proj.weight": partial(fn, is_column=True),
                     "layers.0.mlp.up_proj.weight": partial(fn, is_column=True),
-                    "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                    "lm_head.weight": partial(
+                        fn, is_column=not config.tie_word_embeddings
+                    ),
                     "embed_tokens.weight": partial(fn, is_column=False),
                     "layers.0.self_attn.o_proj.weight": partial(fn, is_column=False),
                     "layers.0.mlp.down_proj.weight": partial(fn, is_column=False),
@@ -1401,9 +1700,15 @@ class ErniePretrainedModel(PretrainedModel):
                 if config.use_bias:
                     base_actions.update(
                         {
-                            "layers.0.self_attn.q_proj.bias": partial(fn, is_column=True),
-                            "layers.0.self_attn.k_proj.bias": partial(fn, is_column=True),
-                            "layers.0.self_attn.v_proj.bias": partial(fn, is_column=True),
+                            "layers.0.self_attn.q_proj.bias": partial(
+                                fn, is_column=True
+                            ),
+                            "layers.0.self_attn.k_proj.bias": partial(
+                                fn, is_column=True
+                            ),
+                            "layers.0.self_attn.v_proj.bias": partial(
+                                fn, is_column=True
+                            ),
                             "layers.0.mlp.gate_proj.bias": partial(fn, is_column=True),
                             "layers.0.mlp.up_proj.bias": partial(fn, is_column=True),
                             "lm_head.bias": partial(fn, is_column=True),
@@ -1418,7 +1723,9 @@ class ErniePretrainedModel(PretrainedModel):
             return final_actions
 
         mappings = get_tensor_parallel_split_mappings(
-            config.num_hidden_layers if not config.remove_tail_layer else config.num_hidden_layers - 1
+            config.num_hidden_layers
+            if not config.remove_tail_layer
+            else config.num_hidden_layers - 1
         )
 
         return mappings
@@ -1448,7 +1755,9 @@ class ErniePretrainedModel(PretrainedModel):
                 dtype = paddle.get_default_dtype()
                 paddle.set_default_dtype("float32")
                 layer.weight.set_value(
-                    paddle.randn(layer.weight.shape, dtype=dtype).scale(self.config.initializer_range)
+                    paddle.randn(layer.weight.shape, dtype=dtype).scale(
+                        self.config.initializer_range
+                    )
                 )
                 paddle.set_default_dtype(dtype)
                 logger.info(
@@ -1459,7 +1768,9 @@ class ErniePretrainedModel(PretrainedModel):
 
         elif isinstance(layer, RotaryEmbedding):
             head_dim = self.config.hidden_size // self.config.num_attention_heads
-            inv_freq = 1.0 / (layer.base ** (np.arange(0, head_dim, 2).astype("float32") / head_dim))
+            inv_freq = 1.0 / (
+                layer.base ** (np.arange(0, head_dim, 2).astype("float32") / head_dim)
+            )
 
             t = np.arange(layer.max_position_embeddings, dtype="float32")
             freqs = np.einsum("i,j->ij", t, inv_freq)
@@ -1494,7 +1805,9 @@ class ErnieModel(ErniePretrainedModel):
         layers_list = [
             ErnieDecoderLayer(config, layer_idx)
             for layer_idx in range(
-                config.num_hidden_layers - 1 if config.remove_tail_layer else config.num_hidden_layers
+                config.num_hidden_layers - 1
+                if config.remove_tail_layer
+                else config.num_hidden_layers
             )
         ]
 
@@ -1512,7 +1825,9 @@ class ErnieModel(ErniePretrainedModel):
         self.embed_tokens = value
 
     @classmethod
-    def _prepare_decoder_attention_mask(cls, attention_mask, input_shape, past_key_values_length, dtype):
+    def _prepare_decoder_attention_mask(
+        cls, attention_mask, input_shape, past_key_values_length, dtype
+    ):
         combined_attention_mask = None
         if input_shape[-1] > 1:
             combined_attention_mask = _make_causal_mask(
@@ -1520,9 +1835,13 @@ class ErnieModel(ErniePretrainedModel):
             )
 
         if attention_mask is not None:
-            expanded_attn_mask = _expand_mask(attention_mask, dtype, tgt_length=input_shape[-1])
+            expanded_attn_mask = _expand_mask(
+                attention_mask, dtype, tgt_length=input_shape[-1]
+            )
             combined_attention_mask = (
-                expanded_attn_mask if combined_attention_mask is None else expanded_attn_mask + combined_attention_mask
+                expanded_attn_mask
+                if combined_attention_mask is None
+                else expanded_attn_mask + combined_attention_mask
             )
         combined_attention_mask = paddle.maximum(
             combined_attention_mask.astype(dtype),
@@ -1576,22 +1895,34 @@ class ErnieModel(ErniePretrainedModel):
         inbatch_pack_offset=None,
         **kwargs,
     ):
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
         output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
         )
         use_cache = use_cache if use_cache is not None else self.config.use_cache
 
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
 
         if input_ids is not None and inputs_embeds is not None:
-            raise ValueError("You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time")
+            raise ValueError(
+                "You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time"
+            )
         elif input_ids is not None:
             batch_size, seq_length = input_ids.shape
         elif inputs_embeds is not None:
             batch_size, seq_length, _ = inputs_embeds.shape
         else:
-            raise ValueError("You have to specify either decoder_input_ids or decoder_inputs_embeds")
+            raise ValueError(
+                "You have to specify either decoder_input_ids or decoder_inputs_embeds"
+            )
 
         if past_key_values is None:
             past_key_values = tuple([None] * len(self.layers))
@@ -1611,7 +1942,9 @@ class ErnieModel(ErniePretrainedModel):
             inputs_embeds = ScatterOp.apply(inputs_embeds)
 
         can_use_fa = self.config.use_flash_attn and flash_attention is not None
-        can_mem_eff_attn = self.config.use_mem_eff_attn and inbatch_pack_offset is not None
+        can_mem_eff_attn = (
+            self.config.use_mem_eff_attn and inbatch_pack_offset is not None
+        )
         if can_use_fa or can_mem_eff_attn:
             if attention_mask is not None:
                 attention_mask = None
@@ -1621,7 +1954,9 @@ class ErnieModel(ErniePretrainedModel):
                     f"attention_mask is not None = {attention_mask is not None}"
                 )
         elif attention_mask is None:
-            attention_mask = paddle.ones((batch_size, seq_length_with_past), dtype=paddle.bool)
+            attention_mask = paddle.ones(
+                (batch_size, seq_length_with_past), dtype=paddle.bool
+            )
 
         if attention_mask is not None:
             attention_mask = self._prepare_decoder_attention_mask(
@@ -1640,7 +1975,9 @@ class ErnieModel(ErniePretrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            past_key_value = past_key_values[idx] if past_key_values is not None else None
+            past_key_value = (
+                past_key_values[idx] if past_key_values is not None else None
+            )
 
             has_gradient = not hidden_states.stop_gradient
             if self.config.use_recompute and has_gradient:
@@ -1686,7 +2023,11 @@ class ErnieModel(ErniePretrainedModel):
         next_cache = next_decoder_cache if use_cache else None
 
         if not return_dict:
-            return tuple(v for v in [hidden_states, next_cache, all_hidden_states, all_self_attns] if v is not None)
+            return tuple(
+                v
+                for v in [hidden_states, next_cache, all_hidden_states, all_self_attns]
+                if v is not None
+            )
         return BaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=hidden_states,
             past_key_values=next_cache,
@@ -1725,7 +2066,9 @@ class FusedHeadParallelCrossEntropy(PyLayer):
 
         if ctx.tensor_parallel_degree > 1:
             ctx.mp_group = (
-                fleet.get_hybrid_communicate_group().get_model_parallel_group() if mp_group is None else mp_group
+                fleet.get_hybrid_communicate_group().get_model_parallel_group()
+                if mp_group is None
+                else mp_group
             )
             ctx.rank = ctx.mp_group.rank
             ctx.world_size = ctx.mp_group.nranks
@@ -1758,7 +2101,9 @@ class FusedHeadParallelCrossEntropy(PyLayer):
                         [ctx.num_tokens_per_rank[idx], hidden_states.shape[-1]],
                         dtype=hidden_states.dtype,
                     )
-                    labels_recv = paddle.empty([ctx.num_tokens_per_rank[idx]], dtype=labels.dtype)
+                    labels_recv = paddle.empty(
+                        [ctx.num_tokens_per_rank[idx]], dtype=labels.dtype
+                    )
 
                 if ctx.tensor_parallel_degree > 1:
                     dist.stream.broadcast(
@@ -1766,7 +2111,9 @@ class FusedHeadParallelCrossEntropy(PyLayer):
                         src=ctx.mp_group.ranks[idx],
                         group=ctx.mp_group,
                     )
-                    dist.stream.broadcast(labels_recv, src=ctx.mp_group.ranks[idx], group=ctx.mp_group)
+                    dist.stream.broadcast(
+                        labels_recv, src=ctx.mp_group.ranks[idx], group=ctx.mp_group
+                    )
 
                 seq_len = hidden_states_recv.shape[0]
                 num_chunk = (seq_len + ctx.seq_chunk_size - 1) // ctx.seq_chunk_size
@@ -1821,7 +2168,9 @@ class FusedHeadParallelCrossEntropy(PyLayer):
 
         hidden_states, weight, bias, labels = ctx.saved_tensor()
 
-        loss_all_grad_list = paddle.split(loss_all_grad, ctx.loss_concat_sections, axis=0)
+        loss_all_grad_list = paddle.split(
+            loss_all_grad, ctx.loss_concat_sections, axis=0
+        )
 
         def detach_variable(inp):
             if inp is None:
@@ -1857,14 +2206,18 @@ class FusedHeadParallelCrossEntropy(PyLayer):
                         [ctx.num_tokens_per_rank[idx], hidden_states.shape[-1]],
                         dtype=hidden_states.dtype,
                     )
-                    labels_recv = paddle.empty([ctx.num_tokens_per_rank[idx]], dtype=labels.dtype)
+                    labels_recv = paddle.empty(
+                        [ctx.num_tokens_per_rank[idx]], dtype=labels.dtype
+                    )
                 if ctx.tensor_parallel_degree > 1:
                     dist.stream.broadcast(
                         hidden_states_recv,
                         src=ctx.mp_group.ranks[idx],
                         group=ctx.mp_group,
                     )
-                    dist.stream.broadcast(labels_recv, src=ctx.mp_group.ranks[idx], group=ctx.mp_group)
+                    dist.stream.broadcast(
+                        labels_recv, src=ctx.mp_group.ranks[idx], group=ctx.mp_group
+                    )
                 hidden_states_recv.stop_gradient = False
 
                 seq_len = hidden_states_recv.shape[0]
@@ -1873,7 +2226,9 @@ class FusedHeadParallelCrossEntropy(PyLayer):
                 for chunk_idx in range(num_chunk):
                     start = chunk_idx * ctx.seq_chunk_size
                     end = min(start + ctx.seq_chunk_size, seq_len)
-                    hidden_states_chunk = hidden_states_recv.slice(axes=[0], starts=[start], ends=[end])
+                    hidden_states_chunk = hidden_states_recv.slice(
+                        axes=[0], starts=[start], ends=[end]
+                    )
                     labels_chunk = labels_recv._slice(start, end)
                     loss_grad_chunk = loss_all_grad_list[idx]._slice(start, end)
 
@@ -1897,10 +2252,12 @@ class FusedHeadParallelCrossEntropy(PyLayer):
                                 ignore_index=ctx.ignore_index,
                             )
                         else:
-                            loss_chunk = paddle.nn.functional.softmax_with_cross_entropy(
-                                logits.cast("float32"),
-                                labels_chunk.unsqueeze(-1),
-                                ignore_index=ctx.ignore_index,
+                            loss_chunk = (
+                                paddle.nn.functional.softmax_with_cross_entropy(
+                                    logits.cast("float32"),
+                                    labels_chunk.unsqueeze(-1),
+                                    ignore_index=ctx.ignore_index,
+                                )
                             )
 
                     with paddle.amp.auto_cast(enable=False):
@@ -1915,7 +2272,9 @@ class FusedHeadParallelCrossEntropy(PyLayer):
 
                 if idx == ctx.rank:
                     hidden_states_grad = hidden_states_recv.grad
-                    hidden_states_grad = hidden_states_grad.reshape(ctx.hidden_states_shape)
+                    hidden_states_grad = hidden_states_grad.reshape(
+                        ctx.hidden_states_shape
+                    )
 
         if weight_main_grad is not None:
             weight_main_grad = weight_main_grad.astype(weight.dtype)
@@ -1942,7 +2301,10 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
         self.ignored_index = getattr(config, "ignored_index", -100)
         self.config = config
         self.return_tuple = return_tuple
-        self.enable_parallel_cross_entropy = config.tensor_parallel_degree > 1 and config.tensor_parallel_output
+        self.enable_parallel_cross_entropy = (
+            config.tensor_parallel_degree > 1 and config.tensor_parallel_output
+        )
+        self.kl_loss_fn = kl_divergence
 
         if self.enable_parallel_cross_entropy:
             self.loss_func = fleet.meta_parallel.ParallelCrossEntropy()
@@ -1952,25 +2314,37 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
             )
         self.token_balance_loss = config.token_balance_loss
 
-    def forward(self, prediction_scores, masked_lm_labels):
+    def forward(
+        self, prediction_scores, masked_lm_labels, kl_logits=None, loss_ratio=None
+    ):
 
+        # print("kl_logits shape:", kl_logits.shape if kl_logits is not None else None)
+        # print("hid_logits shape:", prediction_scores.shape)
         if self.config.use_sparse_head_and_loss_fn:
             hidden_states, outlinear_weight, outlinear_bias = prediction_scores
 
             if self.config.sequence_parallel:
-                masked_lm_labels, sparse_label_idx = sequence_parallel_sparse_mask_labels(
-                    masked_lm_labels, self.ignored_index
+                masked_lm_labels, sparse_label_idx = (
+                    sequence_parallel_sparse_mask_labels(
+                        masked_lm_labels, self.ignored_index
+                    )
                 )
                 sparse_label_idx = sparse_label_idx.reshape([-1, 1])
                 hidden_states = paddle.gather(hidden_states, sparse_label_idx, axis=0)
                 hidden_states = AllGatherVarlenOp.apply(hidden_states)
             else:
                 masked_lm_labels = masked_lm_labels.flatten()
-                sparse_label_idx = paddle.nonzero(masked_lm_labels != self.ignored_index).flatten()
-                masked_lm_labels = paddle.take_along_axis(masked_lm_labels, sparse_label_idx, axis=0)
+                sparse_label_idx = paddle.nonzero(
+                    masked_lm_labels != self.ignored_index
+                ).flatten()
+                masked_lm_labels = paddle.take_along_axis(
+                    masked_lm_labels, sparse_label_idx, axis=0
+                )
 
                 hidden_states = hidden_states.reshape([-1, hidden_states.shape[-1]])
-                hidden_states = paddle.take_along_axis(hidden_states, sparse_label_idx.reshape([-1, 1]), axis=0)
+                hidden_states = paddle.take_along_axis(
+                    hidden_states, sparse_label_idx.reshape([-1, 1]), axis=0
+                )
 
             if self.config.use_recompute_loss_fn:
                 offload_kwargs = {}
@@ -1995,20 +2369,28 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                 res = self.forward_impl(logits, masked_lm_labels)
         elif self.config.use_recompute_loss_fn:
             if self.config.use_fused_head_loss_fn:
-                res = self.forward_impl_with_fused_head_loss_fn(masked_lm_labels, *prediction_scores)
+                res = self.forward_impl_with_fused_head_loss_fn(
+                    masked_lm_labels, *prediction_scores
+                )
             else:
-                assert isinstance(prediction_scores, tuple) and len(prediction_scores) in [3, 4], prediction_scores
+                assert isinstance(prediction_scores, tuple) and len(
+                    prediction_scores
+                ) in [3, 4], prediction_scores
                 res = recompute(
                     self.forward_impl_with_calc_logits,
                     masked_lm_labels,
                     *prediction_scores,
                 )
         else:
-            res = self.forward_impl(prediction_scores, masked_lm_labels)
+            res = self.forward_impl(
+                prediction_scores, masked_lm_labels, kl_logits, loss_ratio
+            )
 
         return res
 
-    def forward_impl_with_fused_head_loss_fn(self, masked_lm_labels, hidden_states, outlinear_weight, outlinear_bias):
+    def forward_impl_with_fused_head_loss_fn(
+        self, masked_lm_labels, hidden_states, outlinear_weight, outlinear_bias
+    ):
         masked_lm_labels.stop_gradient = True
         masked_lm_loss, masked_lm_labels_all = FusedHeadParallelCrossEntropy.apply(
             hidden_states,
@@ -2024,13 +2406,17 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
         )
         lossmask = masked_lm_labels_all != self.ignored_index
         if (~lossmask).all():
-            logger.warning(f"encounter empty span when calculate loss, ignored_index={self.ignored_index}")
+            logger.warning(
+                f"encounter empty span when calculate loss, ignored_index={self.ignored_index}"
+            )
             loss = paddle.mean(masked_lm_loss) * 0.0
             loss_sum = masked_lm_loss.sum().detach()
         else:
             lossmask = lossmask.reshape([-1]).cast(paddle.float32)
 
-            masked_lm_loss = paddle.sum(masked_lm_loss.cast(paddle.float32).reshape([-1]) * lossmask)
+            masked_lm_loss = paddle.sum(
+                masked_lm_loss.cast(paddle.float32).reshape([-1]) * lossmask
+            )
             loss = masked_lm_loss / lossmask.sum()
             if self.token_balance_loss:
                 _loss = masked_lm_loss / self.config.token_balance_seqlen
@@ -2043,7 +2429,9 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
             return loss_sum
         return loss, loss_sum
 
-    def forward_impl_with_calc_logits(self, masked_lm_labels, hidden_states, outlinear_weight, outlinear_bias):
+    def forward_impl_with_calc_logits(
+        self, masked_lm_labels, hidden_states, outlinear_weight, outlinear_bias
+    ):
 
         logits = calc_lm_head_logits(
             self.config,
@@ -2057,22 +2445,27 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
 
     def loss_impl(self, prediction_scores, masked_lm_labels):
         prediction_scores = prediction_scores.cast("float32")
-        masked_lm_loss = self.loss_func(prediction_scores, masked_lm_labels.unsqueeze(-1))
+        masked_lm_loss = self.loss_func(
+            prediction_scores, masked_lm_labels.unsqueeze(-1)
+        )
 
         return masked_lm_loss
 
-    def forward_impl(self, prediction_scores, masked_lm_labels):
+    def forward_impl(
+        self, prediction_scores, masked_lm_labels, kl_logits=None, loss_ratio=None
+    ):
         if self.enable_parallel_cross_entropy:
             assert prediction_scores.shape[-1] != self.config.vocab_size, (
                 f"enable_parallel_cross_entropy, the vocab_size should be splited:"
                 f" {prediction_scores.shape[-1]}, {self.config.vocab_size}"
             )
 
+        kl_loss = paddle.to_tensor(0.0)
         with paddle.amp.auto_cast(False):
             prediction_scores_dims = len(prediction_scores.shape)
-            if prediction_scores_dims == 2 and prediction_scores.shape[0] > self.config.get(
-                "loss_subbatch_seqlen", 32768
-            ):
+            if prediction_scores_dims == 2 and prediction_scores.shape[
+                0
+            ] > self.config.get("loss_subbatch_seqlen", 32768):
                 sb_loss_func = subbatch(
                     self.loss_impl,
                     [0, 1],
@@ -2081,9 +2474,9 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                     0,
                 )
                 masked_lm_loss = sb_loss_func(prediction_scores, masked_lm_labels)
-            elif prediction_scores_dims == 3 and prediction_scores.shape[1] > self.config.get(
-                "loss_subbatch_seqlen", 32768
-            ):
+            elif prediction_scores_dims == 3 and prediction_scores.shape[
+                1
+            ] > self.config.get("loss_subbatch_seqlen", 32768):
                 sb_loss_func = subbatch(
                     self.loss_impl,
                     [0, 1],
@@ -2094,15 +2487,44 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                 masked_lm_loss = sb_loss_func(prediction_scores, masked_lm_labels)
             else:
                 masked_lm_loss = self.loss_impl(prediction_scores, masked_lm_labels)
+                if kl_logits is not None:
+                    # print(self.enable_parallel_cross_entropy)
+                    if self.enable_parallel_cross_entropy:
+                        prediction_scores = DistributedSoftmaxOp.apply(
+                            prediction_scores, axis=-1
+                        )
+                    else:
+                        prediction_scores = F.softmax(
+                            prediction_scores, axis=-1, dtype="float32"
+                        )
+                    kl_logits = F.softmax(kl_logits, axis=-1, dtype="float32")
+                    kl_loss = self.kl_loss_fn(
+                        prediction_scores,
+                        kl_logits,
+                        degree=self.config.tensor_parallel_degree,
+                        rank=self.config.tensor_parallel_rank,
+                    )
+                    print("Kl loss:", kl_loss.mean())
+                    print("ce loss:", masked_lm_loss.mean())
+                    # print("ratio:", loss_ratio)
+                    masked_lm_loss = (
+                        loss_ratio["kl_ratio"][:, None, None] * kl_loss
+                        + loss_ratio["ce_ratio"][:, None, None] * masked_lm_loss
+                    )
+                    print("kl_ce_loss:", masked_lm_loss.mean())
 
             lossmask = masked_lm_labels != self.ignored_index
             if (~lossmask).all():
-                logger.warning(f"encounter empty span when calculate loss, ignored_index={self.ignored_index}")
+                logger.warning(
+                    f"encounter empty span when calculate loss, ignored_index={self.ignored_index}"
+                )
                 loss = paddle.mean(masked_lm_loss) * 0.0
                 loss_sum = masked_lm_loss.sum().detach()
             else:
                 lossmask = lossmask.reshape([-1]).cast(paddle.float32)
-                masked_lm_loss = paddle.sum(masked_lm_loss.cast(paddle.float32).reshape([-1]) * lossmask)
+                masked_lm_loss = paddle.sum(
+                    masked_lm_loss.cast(paddle.float32).reshape([-1]) * lossmask
+                )
                 loss = masked_lm_loss / lossmask.sum()
                 if self.token_balance_loss:
                     _loss = masked_lm_loss / self.config.token_balance_seqlen
@@ -2127,27 +2549,41 @@ class ErnieLMHead(nn.Layer):
 
         self.weight = self.create_parameter(
             shape=(
-                [vocab_size, config.hidden_size] if config.tie_word_embeddings else [config.hidden_size, vocab_size]
+                [vocab_size, config.hidden_size]
+                if config.tie_word_embeddings
+                else [config.hidden_size, vocab_size]
             ),
             dtype=paddle.get_default_dtype(),
         )
-        logger.info(f"output-weight:{self.weight.shape} config.tie_word_embeddings={config.tie_word_embeddings}")
+        logger.info(
+            f"output-weight:{self.weight.shape} config.tie_word_embeddings={config.tie_word_embeddings}"
+        )
         if config.weight_share_add_bias and config.use_bias:
             self.bias = self.create_parameter(
                 shape=[vocab_size],
                 dtype=paddle.get_default_dtype(),
-                attr=paddle.ParamAttr(initializer=paddle.nn.initializer.constant.Constant(0.0)),
+                attr=paddle.ParamAttr(
+                    initializer=paddle.nn.initializer.constant.Constant(0.0)
+                ),
             )
         else:
             self.bias = None
 
-        self.weight.is_distributed = True if (vocab_size != config.vocab_size) else False
+        self.weight.is_distributed = (
+            True if (vocab_size != config.vocab_size) else False
+        )
         if config.weight_share_add_bias and config.use_bias:
-            self.bias.is_distributed = True if (vocab_size != config.vocab_size) else False
+            self.bias.is_distributed = (
+                True if (vocab_size != config.vocab_size) else False
+            )
 
         if self.weight.is_distributed:
             self.weight.split_axis = 1
-        if config.weight_share_add_bias and config.use_bias and self.bias.is_distributed:
+        if (
+            config.weight_share_add_bias
+            and config.use_bias
+            and self.bias.is_distributed
+        ):
             self.bias.split_axis = 0
 
         if self.config.use_recompute_loss_fn:
@@ -2196,7 +2632,9 @@ class ErnieForCausalLM(ErniePretrainedModel):
             ), f"sequence-parallel needs mp>1, got mp={config.tensor_parallel_degree}"
 
         new_initializer_range = math.sqrt(0.3333 / config.hidden_size)
-        logger.info(f"change initializer-range from {config.initializer_range} to {new_initializer_range}")
+        logger.info(
+            f"change initializer-range from {config.initializer_range} to {new_initializer_range}"
+        )
         config.initializer_range = new_initializer_range
         self.config = config
 
@@ -2283,16 +2721,30 @@ class ErnieForCausalLM(ErniePretrainedModel):
 
         return model_inputs
 
-    def update_model_kwargs_for_generation(self, outputs, model_kwargs, is_encoder_decoder=False):
-        if isinstance(outputs, tuple) and len(outputs) > 1 and not isinstance(outputs[1], paddle.Tensor):
+    def update_model_kwargs_for_generation(
+        self, outputs, model_kwargs, is_encoder_decoder=False
+    ):
+        if (
+            isinstance(outputs, tuple)
+            and len(outputs) > 1
+            and not isinstance(outputs[1], paddle.Tensor)
+        ):
             model_kwargs["past_key_values"] = outputs[1]
 
-        if isinstance(outputs, CausalLMOutputWithCrossAttentions) and "past_key_values" in outputs:
+        if (
+            isinstance(outputs, CausalLMOutputWithCrossAttentions)
+            and "past_key_values" in outputs
+        ):
             model_kwargs["past_key_values"] = outputs.past_key_values
 
-        if "token_type_ids" in model_kwargs and model_kwargs["token_type_ids"] is not None:
+        if (
+            "token_type_ids" in model_kwargs
+            and model_kwargs["token_type_ids"] is not None
+        ):
             token_type_ids = model_kwargs["token_type_ids"]
-            model_kwargs["token_type_ids"] = paddle.concat([token_type_ids, token_type_ids[:, -1:]], axis=-1)
+            model_kwargs["token_type_ids"] = paddle.concat(
+                [token_type_ids, token_type_ids[:, -1:]], axis=-1
+            )
 
         if not is_encoder_decoder:
             if "attention_mask" in model_kwargs:
@@ -2306,10 +2758,14 @@ class ErnieForCausalLM(ErniePretrainedModel):
                 )
         if "role_ids" in model_kwargs and model_kwargs["role_ids"] is not None:
             role_ids = model_kwargs["role_ids"]
-            model_kwargs["role_ids"] = paddle.concat([role_ids, role_ids[:, -1:]], axis=-1)
+            model_kwargs["role_ids"] = paddle.concat(
+                [role_ids, role_ids[:, -1:]], axis=-1
+            )
 
         if self.config.rope_3d:
-            assert "position_ids" in model_kwargs, "position_ids must be provided if rope_3d is on"
+            assert (
+                "position_ids" in model_kwargs
+            ), "position_ids must be provided if rope_3d is on"
             position_ids = model_kwargs["position_ids"]
             model_kwargs["position_ids"] = paddle.concat(
                 [
@@ -2339,11 +2795,19 @@ class ErnieForCausalLM(ErniePretrainedModel):
         inbatch_pack_offset=None,
         loss_mask=None,
     ):
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
         )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
 
         outputs = self.ernie(
             input_ids,

--- a/examples/pre-training/models/ernie/modeling.py
+++ b/examples/pre-training/models/ernie/modeling.py
@@ -30,7 +30,6 @@ from models.sequence_parallel_utils import (
     AllGatherVarlenOp,
     ColumnSequenceParallelLinear,
     GatherOp,
-    AllGatherOp,
     RowSequenceParallelLinear,
     ScatterOp,
     mark_as_sequence_parallel_parameter,
@@ -121,98 +120,6 @@ __all__ = [
     "ErniePretrainedModel",
     "ErnieForCausalLM",
 ]
-
-
-class DistributedSoftmaxOp(PyLayer):
-    """
-    分布式Softmax操作，支持模型并行
-    输入形状: [s/n, b, h]，n是模型并行度
-    输出形状: [s/n, b, h]
-    """
-
-    @staticmethod
-    def forward(ctx, x, axis=-1, mp_group=None):
-        """
-        前向传播
-        Args:
-            x: 输入张量 [s/n, b, h]
-            axis: softmax计算的轴
-            mp_group: 模型并行组
-        Returns:
-            softmax_output: softmax输出 [s/n, b, h]
-        """
-        # 保存参数用于反向传播
-        ctx.axis = axis
-        ctx.mp_group = mp_group
-
-        if mp_group is None:
-            hcg = fleet.get_hybrid_communicate_group()
-            ctx.mp_group = hcg.get_model_parallel_group()
-
-        # 1. 数值稳定性处理：减去最大值防止指数运算溢出
-        # 计算本地最大值
-        local_max = paddle.max(x, axis=axis, keepdim=True)
-
-        # 收集所有设备的最大值 - 使用AllGatherOp
-        # 注意：这里需要将最大值在模型并行组内收集
-        all_max = AllGatherOp.apply(local_max, axis=0, group=ctx.mp_group)
-
-        # 计算全局最大值
-        global_max = paddle.max(all_max, axis=0, keepdim=True)
-
-        # 减去全局最大值
-        x_stable = x - global_max
-
-        # 2. 计算指数
-        exp_x = paddle.exp(x_stable.cast("float32"))
-
-        local_sum_exp = paddle.sum(exp_x, axis=axis, keepdim=True)
-
-        sum_exp = mp_ops._mp_allreduce(
-            local_sum_exp,
-            group=mp_group,
-            use_calc_stream=True,
-            use_model_parallel=True,
-        )
-
-        # 4. 计算softmax概率
-        softmax_output = exp_x / sum_exp
-
-        # 保存中间结果用于反向传播
-        ctx.save_for_backward(softmax_output, sum_exp)
-
-        return softmax_output
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        """
-        反向传播
-        Args:
-            grad_output: 上游梯度 [s/n, b, h]
-        Returns:
-            grad_input: 输入梯度 [s/n, b, h]
-        """
-        # 恢复保存的张量
-        softmax_output, global_sum_exp = ctx.saved_tensor()
-        axis = ctx.axis
-        mp_group = ctx.mp_group
-
-        # softmax的梯度公式: dL/dx = softmax * (dL/dy - sum(dL/dy * softmax, axis=axis))
-
-        # 1. 计算 dL/dy * softmax
-        grad_softmax = grad_output * softmax_output
-
-        # 2. 计算 sum(dL/dy * softmax, axis=axis) 的本地部分
-        local_sum_grad = paddle.sum(grad_softmax, axis=axis, keepdim=True)
-
-        # 3. 使用AllGatherOp收集所有设备的局部梯度，然后求和得到全局梯度
-        all_sum_grad = AllGatherOp.apply(local_sum_grad, axis=0, group=mp_group)
-        global_sum_grad = paddle.sum(all_sum_grad, axis=0, keepdim=True)
-
-        # 4. 计算最终梯度
-        grad_input = softmax_output * (grad_output - global_sum_grad)
-
-        return grad_input
 
 
 def kl_divergence(p, q, eps: float = 1e-10, degree=-1, rank=-1):
@@ -2487,31 +2394,28 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                 masked_lm_loss = sb_loss_func(prediction_scores, masked_lm_labels)
             else:
                 masked_lm_loss = self.loss_impl(prediction_scores, masked_lm_labels)
-                if kl_logits is not None:
-                    # print(self.enable_parallel_cross_entropy)
-                    if self.enable_parallel_cross_entropy:
-                        prediction_scores = DistributedSoftmaxOp.apply(
-                            prediction_scores, axis=-1
-                        )
-                    else:
-                        prediction_scores = F.softmax(
-                            prediction_scores, axis=-1, dtype="float32"
-                        )
-                    kl_logits = F.softmax(kl_logits, axis=-1, dtype="float32")
-                    kl_loss = self.kl_loss_fn(
-                        prediction_scores,
-                        kl_logits,
-                        degree=self.config.tensor_parallel_degree,
-                        rank=self.config.tensor_parallel_rank,
-                    )
-                    print("Kl loss:", kl_loss.mean())
-                    print("ce loss:", masked_lm_loss.mean())
-                    # print("ratio:", loss_ratio)
-                    masked_lm_loss = (
-                        loss_ratio["kl_ratio"][:, None, None] * kl_loss
-                        + loss_ratio["ce_ratio"][:, None, None] * masked_lm_loss
-                    )
-                    print("kl_ce_loss:", masked_lm_loss.mean())
+
+            if kl_logits is not None:
+                # print(self.enable_parallel_cross_entropy)
+                prediction_scores = F.softmax(
+                    prediction_scores, axis=-1, dtype="float32"
+                )
+                kl_logits = F.softmax(kl_logits, axis=-1, dtype="float32")
+                kl_loss = self.kl_loss_fn(
+                    prediction_scores,
+                    kl_logits,
+                    degree=self.config.tensor_parallel_degree,
+                    rank=self.config.tensor_parallel_rank,
+                )
+                print("Kl loss:", kl_loss.mean())
+                print("ce loss:", masked_lm_loss.mean())
+                # print("ratio:", loss_ratio)
+                masked_lm_loss = (
+                    loss_ratio[: loss_ratio.shape[0] // 2][:, None, None] * kl_loss
+                    + loss_ratio[loss_ratio.shape[0] // 2 :][:, None, None]
+                    * masked_lm_loss
+                )
+                print("kl_ce_loss:", masked_lm_loss.mean())
 
             lossmask = masked_lm_labels != self.ignored_index
             if (~lossmask).all():

--- a/examples/pre-training/models/ernie/modeling.py
+++ b/examples/pre-training/models/ernie/modeling.py
@@ -135,6 +135,9 @@ def kl_divergence(p, q, eps: float = 1e-10, degree=-1, rank=-1):
     if p.shape[-1] != q.shape[-1]:
         interval_per_rank = q.shape[-1] // degree
         q = q[..., rank * interval_per_rank : (rank + 1) * interval_per_rank]
+
+    p = F.softmax(p, axis=-1, dtype="float32")
+    q = F.softmax(q, axis=-1, dtype="float32")
     p = p + eps
     q = q + eps
 
@@ -2222,7 +2225,12 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
         self.token_balance_loss = config.token_balance_loss
 
     def forward(
-        self, prediction_scores, masked_lm_labels, kl_logits=None, loss_ratio=None
+        self,
+        prediction_scores,
+        masked_lm_labels,
+        kl_logits=None,
+        kl_ids=None,
+        loss_ratio=None,
     ):
 
         # print("kl_logits shape:", kl_logits.shape if kl_logits is not None else None)
@@ -2290,7 +2298,7 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                 )
         else:
             res = self.forward_impl(
-                prediction_scores, masked_lm_labels, kl_logits, loss_ratio
+                prediction_scores, masked_lm_labels, kl_logits, kl_ids, loss_ratio
             )
 
         return res
@@ -2359,7 +2367,12 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
         return masked_lm_loss
 
     def forward_impl(
-        self, prediction_scores, masked_lm_labels, kl_logits=None, loss_ratio=None
+        self,
+        prediction_scores,
+        masked_lm_labels,
+        kl_logits=None,
+        kl_ids=None,
+        loss_ratio=None,
     ):
         if self.enable_parallel_cross_entropy:
             assert prediction_scores.shape[-1] != self.config.vocab_size, (
@@ -2396,20 +2409,22 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
                 masked_lm_loss = self.loss_impl(prediction_scores, masked_lm_labels)
 
             if kl_logits is not None:
-                # print(self.enable_parallel_cross_entropy)
-                prediction_scores = F.softmax(
+                prediction_scores_kl = F.softmax(
                     prediction_scores, axis=-1, dtype="float32"
                 )
-                kl_logits = F.softmax(kl_logits, axis=-1, dtype="float32")
+                prediction_scores_kl = prediction_scores_kl.take_along_axis(
+                    kl_ids, axis=-1
+                )
+
+                kl_logits = paddle.exp(kl_logits)
                 kl_loss = self.kl_loss_fn(
-                    prediction_scores,
+                    prediction_scores_kl,
                     kl_logits,
                     degree=self.config.tensor_parallel_degree,
                     rank=self.config.tensor_parallel_rank,
                 )
                 print("Kl loss:", kl_loss.mean())
                 print("ce loss:", masked_lm_loss.mean())
-                # print("ratio:", loss_ratio)
                 masked_lm_loss = (
                     loss_ratio[: loss_ratio.shape[0] // 2][:, None, None] * kl_loss
                     + loss_ratio[loss_ratio.shape[0] // 2 :][:, None, None]

--- a/examples/pre-training/models/ernie/modeling_moe.py
+++ b/examples/pre-training/models/ernie/modeling_moe.py
@@ -2126,18 +2126,21 @@ class ErniePretrainingCriterion(ErniePretrainingCriterionBase):
                 reduction="none",
             )
 
-    def forward(
-        self, prediction_scores, masked_lm_labels, router_loss=None, mtp_logits=None
-    ):
+    def forward(self, prediction_scores, labels, router_loss=None, mtp_logits=None):
+        masked_lm_labels, kl_logits, loss_ratio = labels
         if self.config.multi_token_pred_depth > 0:
             masked_lm_labels_ori = masked_lm_labels
             masked_lm_labels = masked_lm_labels[
                 :, : -self.config.multi_token_pred_depth
             ]
+            if kl_logits is not None:
+                kl_logits = kl_logits[:, : -self.config.multi_token_pred_depth]
             seq_length = masked_lm_labels.shape[1]
         res = super().forward(
             prediction_scores,
             masked_lm_labels,
+            kl_logits=kl_logits,
+            loss_ratio=loss_ratio,
         )
         global_training_logs = get_global_training_logs()
 

--- a/examples/pre-training/models/ernie/modeling_moe.py
+++ b/examples/pre-training/models/ernie/modeling_moe.py
@@ -2127,7 +2127,7 @@ class ErniePretrainingCriterion(ErniePretrainingCriterionBase):
             )
 
     def forward(self, prediction_scores, labels, router_loss=None, mtp_logits=None):
-        masked_lm_labels, kl_logits, loss_ratio = labels
+        masked_lm_labels, kl_logits, kl_ids, loss_ratio = labels
         if self.config.multi_token_pred_depth > 0:
             masked_lm_labels_ori = masked_lm_labels
             masked_lm_labels = masked_lm_labels[
@@ -2135,11 +2135,13 @@ class ErniePretrainingCriterion(ErniePretrainingCriterionBase):
             ]
             if kl_logits is not None:
                 kl_logits = kl_logits[:, : -self.config.multi_token_pred_depth]
+                kl_ids = kl_ids[:, : -self.config.multi_token_pred_depth]
             seq_length = masked_lm_labels.shape[1]
         res = super().forward(
             prediction_scores,
             masked_lm_labels,
             kl_logits=kl_logits,
+            kl_ids=kl_ids,
             loss_ratio=loss_ratio,
         )
         global_training_logs = get_global_training_logs()

--- a/examples/pre-training/models/ernie/modeling_pp.py
+++ b/examples/pre-training/models/ernie/modeling_pp.py
@@ -154,7 +154,9 @@ class ErnieEmbeddingPipe(nn.Layer):
                         axis=1,
                     )
                     if self.sequence_parallel:
-                        inputs_embeds_mtp = inputs_embeds_mtp.reshape([-1, inputs_embeds_mtp.shape[-1]])
+                        inputs_embeds_mtp = inputs_embeds_mtp.reshape(
+                            [-1, inputs_embeds_mtp.shape[-1]]
+                        )
                         inputs_embeds_mtp = ScatterOp.apply(inputs_embeds_mtp)
                     mtp_emb_res.append(inputs_embeds_mtp)
                 res = paddle.concat(mtp_emb_res)
@@ -178,7 +180,10 @@ class ErnieEmbeddingPipe(nn.Layer):
             ret += (position_ids.clone(),)
         if inbatch_pack_offset is not None:
             ret += (inbatch_pack_offset.clone(),)
-        if self.config.multi_token_pred_depth > 0 and not self.config.enable_mtp_magic_send:
+        if (
+            self.config.multi_token_pred_depth > 0
+            and not self.config.enable_mtp_magic_send
+        ):
             ret += (input_ids,)
             assert len(ret) == 2, "mtp only support one input which is input_ids"
         if len(ret) == 1:
@@ -203,7 +208,9 @@ class MTPEmbeddingPipe(ErnieEmbeddingPipe):
         assert len(input_ids_for_mtp) > 0, "input_ids for mtp is empty"
         hidden_states = args[0]
         input_ids = input_ids_for_mtp.popleft()
-        input_embeds = self.embed_tokens(input_ids).astype(self.embed_tokens.weight.dtype)
+        input_embeds = self.embed_tokens(input_ids).astype(
+            self.embed_tokens.weight.dtype
+        )
 
         return (hidden_states, input_embeds)
 
@@ -225,7 +232,10 @@ class ErnieDecoderLayerPipe(ErnieDecoderLayer):
         self.use_mem_eff_attn = config.use_mem_eff_attn
 
     def forward(self, args):
-        if self.config.multi_token_pred_depth > 0 and not self.config.enable_mtp_magic_send:
+        if (
+            self.config.multi_token_pred_depth > 0
+            and not self.config.enable_mtp_magic_send
+        ):
             res = args[0]
             tensor_list = paddle.split(res, self.config.multi_token_pred_depth + 1)
             inputs_embeds = tensor_list[-self.config.multi_token_pred_depth :]
@@ -267,9 +277,13 @@ class ErnieDecoderLayerPipe(ErnieDecoderLayer):
             if "mod" == setting_type:
                 assert isinstance(offload_value, (list, tuple))
                 v1, v2 = offload_value
-                offload_kwargs["offload_indices"] = [0] if self.layer_idx % v1 == v2 else []
+                offload_kwargs["offload_indices"] = (
+                    [0] if self.layer_idx % v1 == v2 else []
+                )
             elif "layer_idxs" == setting_type:
-                offload_kwargs["offload_indices"] = [0] if self.layer_idx in offload_value else []
+                offload_kwargs["offload_indices"] = (
+                    [0] if self.layer_idx in offload_value else []
+                )
 
             if offload_kwargs.get("offload_indices", []) and res is not None:
                 inplace_offload(res)
@@ -326,13 +340,17 @@ class RMSNormPipe(RMSNorm):
     def forward(self, args):
         if self.config.multi_token_pred_depth > 0:
             if self.config.enable_mtp_magic_send:
-                assert len(args) == self.config.multi_token_pred_depth + 1, "the length is not valid in mtp"
+                assert (
+                    len(args) == self.config.multi_token_pred_depth + 1
+                ), "the length is not valid in mtp"
                 mtp_outputs = []
                 for hidden_states in args:
                     mtp_outputs.append(super().forward(hidden_states))
                 return mtp_outputs
             else:
-                tensor_list = paddle.split(args[0], self.config.multi_token_pred_depth + 1)
+                tensor_list = paddle.split(
+                    args[0], self.config.multi_token_pred_depth + 1
+                )
                 mtp_outputs = []
                 for hidden_states in tensor_list:
                     mtp_outputs.append(super().forward(hidden_states))
@@ -370,16 +388,27 @@ class MTPLayer(nn.Layer):
         self.config = config
         if self.config.use_recompute_mtp:
             self.config.use_recompute = False
-        assert self.config.multi_token_pred_depth > 0, "Adding MTPLayer must assign value to multi_token_pred_depth"
+        assert (
+            self.config.multi_token_pred_depth > 0
+        ), "Adding MTPLayer must assign value to multi_token_pred_depth"
 
         self.mtp_block = paddle.nn.LayerList(
-            [ErnieDecoderLayer(config, layer_idx) for layer_idx in range(self.config.multi_token_pred_depth)]
+            [
+                ErnieDecoderLayer(config, layer_idx)
+                for layer_idx in range(self.config.multi_token_pred_depth)
+            ]
         )
         Norm = RMSNorm
-        self.mtp_hidden_norm = paddle.nn.LayerList([Norm(config) for _ in range(self.config.multi_token_pred_depth)])
-        self.mtp_emb_norm = paddle.nn.LayerList([Norm(config) for _ in range(self.config.multi_token_pred_depth)])
+        self.mtp_hidden_norm = paddle.nn.LayerList(
+            [Norm(config) for _ in range(self.config.multi_token_pred_depth)]
+        )
+        self.mtp_emb_norm = paddle.nn.LayerList(
+            [Norm(config) for _ in range(self.config.multi_token_pred_depth)]
+        )
 
-        LinearFN = paddle.incubate.nn.FusedLinear if config.fuse_linear else paddle.nn.Linear
+        LinearFN = (
+            paddle.incubate.nn.FusedLinear if config.fuse_linear else paddle.nn.Linear
+        )
         self.mtp_linear_proj = paddle.nn.LayerList(
             [
                 LinearFN(
@@ -409,7 +438,9 @@ class MTPLayer(nn.Layer):
         if self.config.enable_mtp_magic_send:
             assert isinstance(args, tuple), "Input for MTPLayer must be tuple"
             hidden_states, inputs_embeds = args
-            inputs_embeds_extra = inputs_embeds[:, -self.config.multi_token_pred_depth :, :]
+            inputs_embeds_extra = inputs_embeds[
+                :, -self.config.multi_token_pred_depth :, :
+            ]
             inputs_embeds = inputs_embeds[:, : -self.config.multi_token_pred_depth, :]
             inputs_embeds_ori = inputs_embeds
         else:
@@ -430,16 +461,22 @@ class MTPLayer(nn.Layer):
                 )
 
                 if self.config.sequence_parallel:
-                    inputs_embeds_cur_depth = inputs_embeds_cur_depth.reshape([-1, inputs_embeds_cur_depth.shape[-1]])
+                    inputs_embeds_cur_depth = inputs_embeds_cur_depth.reshape(
+                        [-1, inputs_embeds_cur_depth.shape[-1]]
+                    )
                     inputs_embeds_cur_depth = ScatterOp.apply(inputs_embeds_cur_depth)
             else:
                 inputs_embeds_cur_depth = inputs_embeds_cur_depth_list[depth]
 
-            inputs_embeds_cur_depth_norm = self.mtp_emb_norm[depth](inputs_embeds_cur_depth)
+            inputs_embeds_cur_depth_norm = self.mtp_emb_norm[depth](
+                inputs_embeds_cur_depth
+            )
             hidden_states_norm = self.mtp_hidden_norm[depth](hidden_states)
 
             inputs_embeds_cur_depth = self.mtp_linear_proj[depth](
-                paddle.concat([inputs_embeds_cur_depth_norm, hidden_states_norm], axis=-1)
+                paddle.concat(
+                    [inputs_embeds_cur_depth_norm, hidden_states_norm], axis=-1
+                )
             )
 
             decoder_layer = self.mtp_block[depth]
@@ -499,24 +536,38 @@ class PipelinePretrainedModel(PretrainedModel):
         self._pp_to_single_mapping = None
 
     def add_sequential_layer(self, layer_desc, name_prefix=""):
-        self._sequential_layers.append({"layer": layer_desc, "name_prefix": name_prefix})
+        self._sequential_layers.append(
+            {"layer": layer_desc, "name_prefix": name_prefix}
+        )
 
     def get_sequential_layers(self):
         return [x["layer"] for x in self._sequential_layers]
 
     def get_sequential_name_prefixs(self):
-        return {str(index): x["name_prefix"] for index, x in enumerate(self._sequential_layers)}
+        return {
+            str(index): x["name_prefix"]
+            for index, x in enumerate(self._sequential_layers)
+        }
 
     def get_shardlayer_prefix(self, name_splited):
-        shared_layer_names = {s.layer_name for s in self._layers_desc if isinstance(s, SharedLayerDesc)}
-        assert name_splited[1] in shared_layer_names, f"The shared layer name {name_splited[1]} must be in prefixes!"
+        shared_layer_names = {
+            s.layer_name for s in self._layers_desc if isinstance(s, SharedLayerDesc)
+        }
+        assert (
+            name_splited[1] in shared_layer_names
+        ), f"The shared layer name {name_splited[1]} must be in prefixes!"
         shared_layer_key = name_splited[1]
         for idx, layer in enumerate(self._layers_desc):
-            if isinstance(layer, SharedLayerDesc) and layer.layer_name == shared_layer_key:
+            if (
+                isinstance(layer, SharedLayerDesc)
+                and layer.layer_name == shared_layer_key
+            ):
                 if self.get_stage_from_index(idx) == self._stage_id:
                     return self.get_sequential_name_prefixs()[str(idx)]
 
-        raise ValueError(f"The shared layer {shared_layer_key} must be in the current stage!")
+        raise ValueError(
+            f"The shared layer {shared_layer_key} must be in the current stage!"
+        )
 
     def _set_pipeline_name_mapping(self, mappings=None):
         if mappings is not None:
@@ -636,7 +687,9 @@ class PipelinePretrainedModel(PretrainedModel):
                 dtype = paddle.get_default_dtype()
                 paddle.set_default_dtype("float32")
                 layer.weight.set_value(
-                    paddle.randn(layer.weight.shape, dtype=dtype).scale(self.config.initializer_range)
+                    paddle.randn(layer.weight.shape, dtype=dtype).scale(
+                        self.config.initializer_range
+                    )
                 )
                 paddle.set_default_dtype(dtype)
 
@@ -651,7 +704,9 @@ class PipelinePretrainedModel(PretrainedModel):
                     moe_num_experts = moe_num_experts[0]
                 if self.config.moe_group_experts:
                     layer.weight.set_value(
-                        paddle.randn(layer.weight.shape, dtype=layer.weight.dtype).scale(self.config.initializer_range)
+                        paddle.randn(
+                            layer.weight.shape, dtype=layer.weight.dtype
+                        ).scale(self.config.initializer_range)
                     )
                 else:
                     layer.weight.set_value(
@@ -664,15 +719,17 @@ class PipelinePretrainedModel(PretrainedModel):
                     for i in range(1, len(self.config.moe_num_experts)):
                         layer_weight = getattr(layer, f"weight_{i}")
                         layer_weight.set_value(
-                            paddle.randn(layer_weight.shape, dtype=layer_weight.dtype).scale(
-                                self.config.initializer_range
-                            )
+                            paddle.randn(
+                                layer_weight.shape, dtype=layer_weight.dtype
+                            ).scale(self.config.initializer_range)
                         )
                 paddle.set_default_dtype(dtype)
 
         elif isinstance(layer, RotaryEmbedding):
             head_dim = self.config.hidden_size // self.config.num_attention_heads
-            inv_freq = 1.0 / (layer.base ** (np.arange(0, head_dim, 2).astype("float32") / head_dim))
+            inv_freq = 1.0 / (
+                layer.base ** (np.arange(0, head_dim, 2).astype("float32") / head_dim)
+            )
 
             t = np.arange(layer.max_position_embeddings, dtype="float32")
             freqs = np.einsum("i,j->ij", t, inv_freq)
@@ -701,14 +758,19 @@ def get_pp_vp_split_layers(config):
     )
 
     chunk_size = layer_num // (pp_size * vp_size)
-    chunk_list = [list(range(i * chunk_size, (i + 1) * chunk_size)) for i in range(pp_size * vp_size)]
+    chunk_list = [
+        list(range(i * chunk_size, (i + 1) * chunk_size))
+        for i in range(pp_size * vp_size)
+    ]
 
     stage_chunk_list = [[] for _ in range(pp_size)]
     for i in range(pp_size * vp_size):
         stage_chunk_list[i % pp_size].append(chunk_list[i])
 
     if config.use_recompute_attn:
-        logger.error("selective recompute only support full recompute now, please set use_recompute_attn to False")
+        logger.error(
+            "selective recompute only support full recompute now, please set use_recompute_attn to False"
+        )
 
     for i in range(pp_size):
         no_recompute_layer_num.extend(stage_chunk_list[i][-selective_no_recompute_num:])
@@ -749,7 +811,14 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
         )
         if len(inputs) == 1:
             inputs = inputs[0]
-        labels = [d["labels"] for d in data]
+        label_item_num = len(data[0]["labels"])
+        if label_item_num == 1:
+            labels = [d["labels"] for d in data]
+        else:
+            # kl cpt
+            labels = tuple(
+                [[d["labels"][idx] for d in data] for idx in range(label_item_num)]
+            )
         return inputs, labels
 
     def __init__(
@@ -764,7 +833,9 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
 
         if config.moe_group in {"mp", "model", "tp", "mpdp"}:
             assert config.sequence_parallel
-            logger.info(f"disable FFN tensor model parallel, moe-group={config.moe_group}")
+            logger.info(
+                f"disable FFN tensor model parallel, moe-group={config.moe_group}"
+            )
             config.disable_ffn_model_parallel = True
 
         config.moe_group = _parse_moe_group(config.moe_group)
@@ -801,12 +872,18 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
 
         insert_empty_layer = config.insert_empty_layer
         if len(insert_empty_layer) > 0:
-            assert min(insert_empty_layer) >= 0, "cannot insert empty layer as first layer of the model"
-            assert max(insert_empty_layer) < config.num_hidden_layers, "empty layers location exceed the num layers"
+            assert (
+                min(insert_empty_layer) >= 0
+            ), "cannot insert empty layer as first layer of the model"
+            assert (
+                max(insert_empty_layer) < config.num_hidden_layers
+            ), "empty layers location exceed the num layers"
         logger.info(f"use insert_empty_layer: {insert_empty_layer}")
 
         if config.multi_token_pred_depth == 0:
-            self.add_sequential_layer(LayerDesc(self.ErnieEmbeddingPipeClass, config=config), "ernie")
+            self.add_sequential_layer(
+                LayerDesc(self.ErnieEmbeddingPipeClass, config=config), "ernie"
+            )
         else:
             if config.enable_mtp_magic_send:
                 self.add_sequential_layer(
@@ -819,9 +896,13 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
                     "ernie.embed",
                 )
             else:
-                self.add_sequential_layer(LayerDesc(self.ErnieEmbeddingPipeClass, config=config), "ernie")
+                self.add_sequential_layer(
+                    LayerDesc(self.ErnieEmbeddingPipeClass, config=config), "ernie"
+                )
 
-        num_empty_layers = config.remove_tail_layer if isinstance(config.remove_tail_layer, int) else 1
+        num_empty_layers = (
+            config.remove_tail_layer if isinstance(config.remove_tail_layer, int) else 1
+        )
         for i in range(config.num_hidden_layers - num_empty_layers):
             self.add_sequential_layer(
                 LayerDesc(
@@ -851,7 +932,9 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
                     ),
                     "embed_share",
                 )
-            self.add_sequential_layer(LayerDesc(self.MTPLayerClass, config=config), "ernie")
+            self.add_sequential_layer(
+                LayerDesc(self.MTPLayerClass, config=config), "ernie"
+            )
             num_empty_layers = num_empty_layers - config.multi_token_pred_depth
 
         if config.remove_tail_layer:
@@ -888,14 +971,22 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
             "ernie.norm",
         )
 
-        self.add_sequential_layer(LayerDesc(self.ErnieMoELMHeadPipeClass, config=config), "lm_head")
+        self.add_sequential_layer(
+            LayerDesc(self.ErnieMoELMHeadPipeClass, config=config), "lm_head"
+        )
 
         recompute_interval = 0
 
         seg_method = "layer:ErnieDecoderLayer|EmptyLayer|MTPLayer"
-        if config.num_hidden_layers % fleet.get_hybrid_communicate_group().topology().get_dim_size("pipe") != 0:
+        if (
+            config.num_hidden_layers
+            % fleet.get_hybrid_communicate_group().topology().get_dim_size("pipe")
+            != 0
+        ):
             seg_method = "uniform"
-        logger.info(f"using recompute_interval={recompute_interval}, seg_method={seg_method}")
+        logger.info(
+            f"using recompute_interval={recompute_interval}, seg_method={seg_method}"
+        )
 
         PipelineLayer.__init__(
             self,
@@ -925,7 +1016,9 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
     def fp8_quant_weight(self):
         with paddle.no_grad():
             for i, layer in self._sub_layers.items():
-                if isinstance(layer, ErnieDecoderLayer) and hasattr(layer, "fp8_quant_weight"):
+                if isinstance(layer, ErnieDecoderLayer) and hasattr(
+                    layer, "fp8_quant_weight"
+                ):
                     layer.fp8_quant_weight()
 
     def _post_init(self, original_init, *args, **kwargs):
@@ -981,12 +1074,17 @@ class ErnieMoEForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
             if k not in self._pipeline_name_mapping:
                 continue
             state_dict[self._pipeline_name_mapping[k]] = v
-        missing_keys, mismatch_keys = super().set_state_dict(state_dict, *args, **kwargs)
+        missing_keys, mismatch_keys = super().set_state_dict(
+            state_dict, *args, **kwargs
+        )
 
         missing_shared_keys = self._check_shared_model_state()
         tmp_missing_keys = []
         for key in missing_keys:
-            if key in missing_shared_keys and missing_shared_keys[key] not in missing_keys:
+            if (
+                key in missing_shared_keys
+                and missing_shared_keys[key] not in missing_keys
+            ):
                 continue
             tmp_missing_keys.append(key)
         missing_keys = tmp_missing_keys

--- a/examples/pre-training/tools/logprobs_vllm_server.py
+++ b/examples/pre-training/tools/logprobs_vllm_server.py
@@ -48,11 +48,10 @@ def init_model(model_name, tensor_parallel_size: int = 1):
     llm = LLM(
         model=model_name,
         tensor_parallel_size=tensor_parallel_size,
-        gpu_memory_utilization=0.5,
+        gpu_memory_utilization=0.9,
         max_model_len=8192,
         trust_remote_code=True,
         max_logprobs=-1,
-        distributed_executor_backend="ray",
     )
 
 
@@ -67,9 +66,9 @@ async def generate_logit(request: PromptRequest):
         detokenize=False,
         n=1,
     )
-    if tuple(request.max_tokens) in query_cache:
+    if tuple(request.prompt_token_ids[0]) in query_cache:
         buffer = io.BytesIO()
-        pickle.dump(query_cache[tuple(request.max_tokens)], buffer)
+        pickle.dump(query_cache[tuple(request.prompt_token_ids[0])], buffer)
         buffer.seek(0)
         return Response(content=buffer.read(), media_type="application/octet-stream")
 
@@ -101,7 +100,7 @@ async def generate_logit(request: PromptRequest):
         "logits": all_token,
         "ids": all_ids,
     }
-    query_cache[tuple(request.max_tokens)] = package
+    query_cache[tuple(request.prompt_token_ids[0])] = package
     buffer = io.BytesIO()
     pickle.dump(package, buffer)
     buffer.seek(0)

--- a/examples/pre-training/tools/logprobs_vllm_server.py
+++ b/examples/pre-training/tools/logprobs_vllm_server.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import FastAPI, Response
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from vllm import LLM, SamplingParams
+from vllm.inputs.data import TokensPrompt
+
+import io
+import argparse
+import pickle
+
+query_cache = {}
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_headers=["*"],
+    allow_methods=["*"],
+)
+
+
+class PromptRequest(BaseModel):
+    prompt_token_ids: list[list[int]]
+    max_tokens: int = 1
+    temperature: float = 0.7
+    top_p: float = 0.95
+    prompt_logprobs: int = -1
+    logprobs: int = -1
+
+
+def init_model(model_name, tensor_parallel_size: int = 1):
+    global llm
+    llm = LLM(
+        model=model_name,
+        tensor_parallel_size=tensor_parallel_size,
+        gpu_memory_utilization=0.5,
+        max_model_len=8192,
+        trust_remote_code=True,
+        max_logprobs=-1,
+        distributed_executor_backend="ray",
+    )
+
+
+@app.post("/generate")
+async def generate_logit(request: PromptRequest):
+    sampling_params = SamplingParams(
+        max_tokens=request.max_tokens,
+        temperature=request.temperature,
+        top_p=request.top_p,
+        prompt_logprobs=request.prompt_logprobs,
+        logprobs=request.logprobs,
+        detokenize=False,
+        n=1,
+    )
+    if tuple(request.max_tokens) in query_cache:
+        buffer = io.BytesIO()
+        pickle.dump(query_cache[tuple(request.max_tokens)], buffer)
+        buffer.seek(0)
+        return Response(content=buffer.read(), media_type="application/octet-stream")
+
+    outputs = llm.generate(
+        TokensPrompt(prompt_token_ids=request.prompt_token_ids[0]),
+        sampling_params=sampling_params,
+        use_tqdm=True,
+    )
+    for output in outputs:
+        prompt_logprobs = output.prompt_logprobs
+        all_token = []
+        all_ids = []
+        # prompt probs
+        for d in range(len(prompt_logprobs[1:])):
+            token_probs = []
+            ids = sorted(prompt_logprobs[1:][d].keys())[: request.prompt_logprobs]
+            for idx in ids:
+                token_probs.append(prompt_logprobs[1:][d][idx].logprob)
+            all_token.append(token_probs)
+            all_ids.append(ids)
+        # decode probs
+        decode_probs = []
+        decode_ids = sorted(output.outputs[0].logprobs[0])[: request.logprobs]
+        for idx in decode_ids:
+            decode_probs.append(output.outputs[0].logprobs[0][idx].logprob)
+        all_token.append(decode_probs)
+        all_ids.append(decode_ids)
+    package = {
+        "logits": all_token,
+        "ids": all_ids,
+    }
+    query_cache[tuple(request.max_tokens)] = package
+    buffer = io.BytesIO()
+    pickle.dump(package, buffer)
+    buffer.seek(0)
+    return Response(content=buffer.read(), media_type="application/octet-stream")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, required=True, help="model_path")
+    parser.add_argument("--tp", type=int, default=1, help="Tensor_parallel")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="host_ip")
+    parser.add_argument("--port", type=int, default=8008, help="host_port")
+    args = parser.parse_args()
+
+    print(f"Loading Model: {args.model}")
+
+    init_model(args.model, args.tp)
+
+    print("Loaded Model !")
+
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/examples/pre-training/yamls/ERNIE-4p5-300B-A47B/continual_pretrain_96_gpus.yaml
+++ b/examples/pre-training/yamls/ERNIE-4p5-300B-A47B/continual_pretrain_96_gpus.yaml
@@ -1,0 +1,122 @@
+# -----------环境变量----------------------#
+env:
+    HOME: null
+
+# ---------------------------model args-------------------------------------------------#
+model_args:
+    model_name_or_path: model_configs/ERNIE-4p5-300B-A47B/
+    tokenizer_name: ./ernie/src/tokenizers/tokenizer_model
+    output_dir: ./output/
+    data_load_process_num: 40
+    max_seq_length: 4096
+    base_seq_length: 4096
+    num_consecutive: 32
+
+    enable_global_training_logs: False
+    moe_use_aux_free_update_coef: 0.001
+    global_logging_interval: 10
+    enable_mtp_magic_send: True
+
+    model_config:
+        multi_token_pred_depth: 1
+        use_ep_comm_overlap: false
+        use_combine_before_a2a: true
+        use_rms_qkv_recompute: true
+
+        moe_logging: True
+        moe_use_aux_free: true
+        use_recompute: true
+        use_fp8_mlp: false
+        use_fp8_fuse_node: false
+        fp8_mem_configs:
+            shared_expert: false
+            recompute_fwd_gate_up: [4, 5, 6, 7, 8, 10, 11, 12, 13, 16, 17, 18]
+            dequant_input: true
+        fp8_fused_ops_configs:
+            stack_quant: true
+            swiglu_probs_bwd: true
+            split_group_gemm: false
+            spaq: true
+            transpose_split_quant: true
+
+        moe_gate: top2_fused
+
+
+
+# ---------------------------trainer args-------------------------------------------------#
+trainer_args:
+    input_dir: "0.4 ./demo_data/data-1-part0 0.6 ./demo_data/data-1-part1::CPT"
+    split: "998,1,1"
+
+    use_sp_callback: true
+    moe_gate_lr_ratio: 0.01
+    do_train: True
+    dataloader_num_workers: 8
+    prefetch_factor: 32
+    overwrite_output_dir: 1
+    disable_tqdm: 1
+    logging_steps: 1
+    eval_steps: 1000
+    eval_iters: -1
+    save_steps: 100
+    max_steps: 100
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_epsilon: 1e-8
+    learning_rate: 2.2e-4
+    min_lr: 2.2e-5
+    self_constraint_cpt: true
+    prob_nums: 10
+    cpt_kl_ratio: 0.5
+    pt_kl_ratio: 1.0
+    cpt_ce_ratio: 1.0
+    pt_ce_ratio: 0.5
+
+    gradient_accumulation_steps: 20
+    per_device_train_batch_size: 1
+    per_device_eval_batch_size: 1
+
+    lr_scheduler: wsd:231084
+    decay_function: 1-sqrt
+    max_grad_norm: 1.0
+    use_async_save: True
+
+    weight_decay: 0.1
+    warmup_steps: 200
+    save_total_limit: 5
+    bf16: True
+    fp16_opt_level: "O2"
+    use_fp8: False
+    scale_loss: 4096
+    seed: 666
+    use_train_part_sharding: 1
+    pre_alloc_memory: 60
+    offload_optim: True
+
+    pipeline_parallel_degree: 12
+    tensor_parallel_degree: 1
+    virtual_pp_degree: 1
+    data_parallel_degree: 1
+    expert_parallel_degree: 8
+    sharding: "stage1"
+    sharding_parallel_degree: 8
+    amp_master_grad: 1
+    pipeline_parallel_config: enable_delay_scale_loss enable_overlap_p2p_comm best_unbalanced_scheduler
+    sharding_parallel_config: split_param
+    sharding_comm_buffer_size_MB: 2048
+    tensor_parallel_config: sync_param sync_grad sync_moment
+    hybrid_parallel_topo_order: sharding_first
+
+    skip_profile_timer: True
+    ignore_data_skip: 0
+    shuffle_consecutive: True
+    load_sharded_model: True
+    save_sharded_model: True
+    ignore_load_lr_and_optim: False
+    metrics_output_path: ./output/paddle_distributed_logs/
+    use_moe: true
+    moe_with_send_router_loss: False
+    moe_group: ep
+    log_global_grad_norm: True
+    enable_optimizer_timer: False
+    gc_interval: 100000


### PR DESCRIPTION
### 数据集配置

在配置Yaml中由<b>input_dir</b>这一项配置数据集路径，格式为<b>"sample_weight dataset_dir"</b>，例如`"0.4 ./demo_data/data-1-part0"`，对于cpt中的垂类数据，需带上特殊后缀::CPT，标记后的样本会走不同的kl/ce loss混合比例，如：

` input_dir: "0.4 ./demo_data/data-1-part0 0.6 ./demo_data/data-1-part1::CPT"`

上面例子中./demo_data/data-1-part0数据采样率0.4会走通用数据loss ratio，./demo_data/data-1-part1数据采样率0.6会走垂类数据loss ratio。

<hr>

### 推理部署
Domain self-constraint 继续预训练需要预先启动推理脚本用于做logprobs服务器，命令如下：

```shell
python examples/pre-training/tools/logprobs_vllm_server.py --model /path/to/model --tp 8
```

<hr>

### 正式训练
正式训练需要通过环境变量指定Logprobs server地址
- INFER_SERVER_IP：server ip
- INFER_SERVER_PORT：server port

```shell
INFER_SERVER_IP=127.0.0.1 INFER_SERVER_PORT=8008 bash examples/pre-training/scripts/ERNIE-4p5-300B-A47B/train_96_gpus.sh
```

### 其他配置
对于通用/垂类数据的KL/CE loss 比例提供了专门的参数配置入口

```yaml
# 垂类kl加权比例
cpt_kl_ratio: 0.5
# 通用kl加权比例
pt_kl_ratio: 1.0
# 垂类ce加权比例
cpt_ce_ratio: 1.0
# 通用ce加权比例
pt_ce_ratio: 0.5
```

同时还提供了Logprobs topK配置：

```yaml
# 返回top10 logprobs
prob_nums: 10
```