### PR TITLE
Implement huggingface checkpoint loading and export

### DIFF
--- a/examples/pre-training/ernie/pretrain.py
+++ b/examples/pre-training/ernie/pretrain.py
@@ -35,6 +35,10 @@ from paddleformers.trainer import (
     PdArgumentParser,
     get_last_checkpoint,
 )
+from paddleformers.trainer.unified_checkpoint import unified_checkpoint
+from paddleformers.transformers.model_utils import unwrap_model
+
+from safetensors import safe_open
 
 try:
     from paddleformers.utils.downloader import get_static_model_on_pdc
@@ -200,6 +204,184 @@ def create_pretrained_dataset(args):
         }
 
     return train_dataset, valid_dataset, test_dataset, _collate_data
+
+
+def load_huggingface_checkpoint(model, args):
+    fused_rms_norm_replace = [
+        ("self_attn.fused_rms_norm_linear.rms_norm_weight", "input_layernorm.weight"),
+        ("self_attn.fused_rms_norm_linear.linear_weight", "self_attn.qkv_proj.weight"),
+    ]
+    shared_layers_prefix = "shared_layers.embed_weight_share."
+    unnamed_layers = ["ernie.norm.weight", "lm_head.weight"]
+
+    logger.info(f"Loading huggingface checkpoint from {args.model_name_or_path}")
+    with open(
+        os.path.join(args.model_name_or_path, "model.safetensors.index.json")
+    ) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    ep_degree = fleet.get_hybrid_communicate_group().get_expert_parallel_world_size()
+    ep_rank = fleet.get_hybrid_communicate_group().get_expert_parallel_rank()
+    expert_offset = (model.config.moe_num_experts // ep_degree) * ep_rank
+    use_torch_format = False
+
+    def param_to_weight(name):
+        # for PP=1, we only need to substitute the fused_rms_norm and expert_id
+        for src, dst in fused_rms_norm_replace:
+            name = name.replace(src, dst)
+        if m := re.search(r"mlp\.experts\.(\d+)", name):
+            expert_id = expert_offset + int(m.group(1))
+            s, e = m.span()
+            name = name[:s] + f"mlp.experts.{expert_id}" + name[e:]
+        if isinstance(model, ErnieMoEForCausalLM):
+            return name
+
+        # for PP>1, we also need to handle special layers and adjust layer_idx
+        if name.startswith(shared_layers_prefix):
+            return "ernie." + name[len(shared_layers_prefix) :]
+        layer_idx, stem = name.split(".", maxsplit=1)
+        if stem == "weight":
+            return unnamed_layers.pop(0)
+        if stem.startswith("mtp"):
+            return f"ernie.{stem}"
+        return f"ernie.layers.{int(layer_idx) - 1}.{stem}"
+
+    def try_torch_format(weight_key):
+        if weight_key.startswith("ernie."):
+            weight_key = "model." + weight_key[6:]
+
+        key_decompose = [weight_key]
+        if ".up_gate_proj." in weight_key:
+            key_decompose = [
+                weight_key.replace(".up_gate_proj.", ".gate_proj."),
+                weight_key.replace(".up_gate_proj.", ".up_proj."),
+            ]
+        elif ".qkv_proj." in weight_key:
+            key_decompose = [
+                weight_key.replace(".qkv_proj.", ".q_proj."),
+                weight_key.replace(".qkv_proj.", ".k_proj."),
+                weight_key.replace(".qkv_proj.", ".v_proj."),
+            ]
+
+        tensor_decompose = []
+        for key in key_decompose:
+            if not (weight_file := weight_map.get(key)):
+                return None
+            with safe_open(
+                os.path.join(args.model_name_or_path, weight_file),
+                framework="numpy",
+            ) as f:
+                tensor = paddle.to_tensor(f.get_tensor(key))
+            if "_proj." in key or ".gate." in key:
+                tensor = tensor.T.contiguous()
+            tensor_decompose.append(tensor)
+
+        if len(tensor_decompose) == 1:
+            return tensor_decompose[0]
+        else:
+            return paddle.concat(tensor_decompose, axis=-1)
+
+    def auto_fix_shape(param, weight):
+        assert len(param.shape) == len(weight.shape), "rank not match"
+        assert all(
+            p_dim <= w_dim for p_dim, w_dim in zip(param.shape, weight.shape)
+        ), "weight too small"
+        indices = tuple(slice(0, dim) for dim in param.shape)
+        return weight[indices].contiguous()
+
+    for name, param in model.named_parameters():
+        weight_key = param_to_weight(name)
+        if weight_file := weight_map.get(weight_key):
+            with safe_open(
+                os.path.join(args.model_name_or_path, weight_file),
+                framework="numpy",
+            ) as f:
+                weight = paddle.to_tensor(f.get_tensor(weight_key))
+        elif (weight := try_torch_format(weight_key)) is not None:
+            use_torch_format = True
+        else:
+            logger.warning(
+                f"param `{name}`'s weight `{weight_key}` not found. "
+                "Skip initializing."
+            )
+            continue
+        if use_torch_format and "lm_head" in weight_key:
+            weight = weight.T.contiguous()
+        if param.shape != weight.shape:
+            logger.warning(
+                f"param `{name}`'s shape doesn't match weight `{weight_key}`: "
+                f"{param.shape} and {weight.shape}. Auto fixing."
+            )
+            weight = auto_fix_shape(param, weight)
+        param.copy_(weight)
+
+
+def get_expected_state_dict(model, **kwargs):
+    fused_rms_norm_replace = [
+        ("self_attn.fused_rms_norm_linear.rms_norm_weight", "input_layernorm.weight"),
+        ("self_attn.fused_rms_norm_linear.linear_weight", "self_attn.qkv_proj.weight"),
+    ]
+    shared_layers_prefix = "embed_share."
+
+    model = unwrap_model(model)
+    hcg = fleet.get_hybrid_communicate_group()
+    ep_degree = hcg.get_expert_parallel_world_size()
+    ep_rank = hcg.get_expert_parallel_rank()
+    expert_offset = (model.config.moe_num_experts // ep_degree) * ep_rank
+
+    if model.config.head_dim is None:
+        head_dim = model.config.hidden_size // model.config.num_attention_heads
+    else:
+        head_dim = model.config.head_dim
+    q_dim = head_dim * model.config.num_attention_heads
+    kv_dim = head_dim * model.config.num_key_value_heads
+
+    def copy_attr(out, param):
+        if hasattr(param, "is_distributed"):
+            out.is_distributed = param.is_distributed
+        if hasattr(param, "no_sync"):
+            out.no_sync = param.no_sync
+        return out
+
+    def param_to_weight(name):
+        # for PP=1, we only need to substitute the fused_rms_norm and expert_id
+        for src, dst in fused_rms_norm_replace:
+            name = name.replace(src, dst)
+        if m := re.search(r"\.experts\.(\d+)\.", name):
+            expert_id = expert_offset + int(m.group(1))
+            s, e = m.span()
+            name = name[:s] + f".experts.{expert_id}." + name[e:]
+        if isinstance(model, ErnieMoEForCausalLM):
+            return name
+
+        # for PP>1, we also need to handle shared layers
+        if name.startswith(shared_layers_prefix):
+            return "ernie." + name[len(shared_layers_prefix) :]
+        return name
+
+    state_dict = {}
+    for name, param in model.state_dict().items():
+        name = param_to_weight(name)
+        if name.startswith("ernie."):
+            name = "model." + name[6:]
+
+        if "_proj." in name or ".gate." in name or "lm_head" in name:
+            param = copy_attr(param.T, param)
+
+        if ".up_gate_proj." in name:
+            gate, up = param.split(2)
+            gate, up = copy_attr(gate, param), copy_attr(up, param)
+            state_dict[name.replace(".up_gate_proj.", ".gate_proj.")] = gate
+            state_dict[name.replace(".up_gate_proj.", ".up_proj.")] = up
+        elif ".qkv_proj." in name:
+            assert q_dim + kv_dim * 2 == param.shape[0]
+            state_dict[name.replace(".qkv_proj.", ".q_proj.")] = param[:q_dim]
+            state_dict[name.replace(".qkv_proj.", ".k_proj.")] = param[q_dim:-kv_dim]
+            state_dict[name.replace(".qkv_proj.", ".v_proj.")] = param[-kv_dim:]
+        else:
+            state_dict[name] = param
+
+    return state_dict
 
 
 def main():
@@ -520,21 +702,12 @@ def main():
         cfg.enable_delay_scale_loss = args.enable_delay_scale_loss
         register_pp_reshard_information(cfg.num_hidden_layers)
 
-        if args.from_scratch:
-            model = ErnieMoEForCausalLMPipe(cfg)
-        else:
-            model = ErnieMoEForCausalLMPipe.from_pretrained(
-                args.model_name_or_path,
-                config=cfg,
-            )
+        model = ErnieMoEForCausalLMPipe(cfg)
     else:
-        if args.from_scratch:
-            model = ErnieMoEForCausalLM(cfg)
-        else:
-            model = ErnieMoEForCausalLM.from_pretrained(
-                args.model_name_or_path,
-                config=cfg,
-            )
+        model = ErnieMoEForCausalLM(cfg)
+
+    if not args.from_scratch:
+        load_huggingface_checkpoint(model, args)
 
     cfg = model.config
     logger.info(f"using model type:{type(model)}")
@@ -581,6 +754,7 @@ def main():
     if args.do_train:
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         metrics = train_result.metrics
+        unified_checkpoint.get_expected_state_dict = get_expected_state_dict
         trainer.save_model(args.output_dir)
         trainer.log_metrics("train", metrics)
         trainer.save_metrics("train", metrics)


### PR DESCRIPTION
### 实现正确的Huggingface Checkpoint加载&导出功能

由于该模型的 expert_id 是局部的，所以之前用 from_pretrained 无法正确加载 expert 权重，本PR重写了加载逻辑，现在可以正确映射 expert_id 了，21B和300B模型均可使用

<hr>

### 简介

我们现在checkpoint有两种格式，一种是训练专用的格式，会把优化器状态也保存下来，方便进行checkpoint断点接续；另一种是unified模式，只保存模型本体，训推都能用，但是loss就不接续了，所以一般只在训练完导出给推理的时候才用

由于checkpoint格式不同，所以首次训练、断点接续和导出需要用不同的配置，如下所示：

#### 首次训练
首次开始训练时，需在trainer_args下面将save_to_hf设为false：
```yaml
trainer_args:
    save_to_hf: false
```
（如果没有这个参数需要新增，有的话就修改，下同）

#### 断点接续
假设之前保存了训练100个step时的checkpoint，然后停掉了，想从100 step继续训练，则在trainer_args下面指定：
```yaml
trainer_args:
    resume_from_checkpoint: ./output/checkpoint-100
    save_to_hf: false
```

#### 最终导出
假设想导出训练500个step时的checkpoint，则在trainer_args下面指定：
```yaml
trainer_args:
    resume_from_checkpoint: ./output/checkpoint-500
    save_to_hf: true
    unified_checkpoint: true
    max_steps: 1
```
（相当于假装从500 step恢复训练，但不跑任何step，不更新权重，直接保存为unified格式）

<b>警告：</b>`trainer_args: from_scratch: 0/1`参数需全程保持一致，也就是说如果你在首次训练时用了`from_scratch: 0`，那后面断点接续和最终导出时也必须使用`from_scratch: 0`，不能改成`1`，反之亦然，否则你会发现加载权重的 loss 非常高！

<hr>

### 运行预训练

1. 下载好相应模型的权重，以`ERNIE-4.5-300B-A47B-Base-Paddle`为例

2. 由于下载的权重中的 config.json 是按照推理来的，一些参数甚至会报错，所以需要用本仓库中针对训练的`model_configs/ERNIE-4p5-300B-A47B/model_config.json`替换掉原有 config.json

3. 在模型的yaml中，修改以下2个参数
  ```yaml
  model_name_or_path: /path/to/your/ERNIE-4.5-300B-A47B-Base-Paddle
  from_scratch: 0
  ```

4. 为了加快测试速度和避免显存问题，建议也修改以下参数
  ```yaml
  use_recompute: true  # 最大显存68G
  use_fp8_mlp: false        # 加快启动速度，约5min
  use_fp8_fuse_node: false  # 同上
  gradient_accumulation_steps: 20  # 每step约30s
  save_to_hf: false  # 用新版paddleformers时需设置，否则保存的checkpoint无法加载
  ```

5. 然后按照`scripts/ERNIE-4p5-300B-A47B/train_96_gpus.sh`启动即可

#### 环境建议
* 使用原版镜像，不要更新 paddle 和 torch，仅更新 transformers==4.55.1 aistudio-sdk==0.3.8 即可
* paddleformers 建议用 origin/release/v0.2 版本，不要用太新的版本，否则保存的 checkpoint 不兼容，当然如果你不用 checkpoint 转换功能可以不用管
* 如果报错 vocab_size 不匹配，可以检查下模型的 config.json 中是否为`"vocab_size": 103424`，本仓库的值可能和模型不一样，以模型的为准

#### 正确性确认
* 21B首轮loss约2.1，global_grad_norm约20
* 300B
  * 对齐版本首轮loss约2.2，global_grad_norm约100
  * Base版本首轮loss约1.6，global_grad_norm约30