### PR TITLE
update error message for overly long input

### DIFF
--- a/data_processor/steps/input_ids_messaging/example_to_feature.py
+++ b/data_processor/steps/input_ids_messaging/example_to_feature.py
@@ -490,9 +490,12 @@ class ExampleToFeature(ProcessorBase):
             split_token_num = sum(truncate_ids == split_token_id)
             if split_token_num < min_num:
                 raise ValueError(
-                    f"The data is too long and cannot be truncated, ids: \
-                        {len(ids)}, len images: {len(meta['image_info'])}, \
-                        ids == self.image_token_id {sum(np.array(ids) ==self.image_token_id)}"
+                    f"The data is too long and cannot be truncated.\n"
+                    f"Current sequence stats:\n"
+                    f"  - ids length: {len(ids)}\n"
+                    f"  - number of images: {len(meta['image_info'])}\n"
+                    f"  - image token count (id == {self.image_token_id}): {sum(np.array(ids) == self.image_token_id)}\n"
+                    f"To resolve this, consider increase `max_seq_len`"
                 )
             indices = np.where(truncate_ids == split_token_id)[0]
             truncate_pos = indices[-1]


### PR DESCRIPTION
Update the ValueError raised when input exceeds truncation limits.
This helps users quickly diagnose and resolve sequence length issues.