### PR TITLE
Add global recompute param and update P800 config

### DIFF
--- a/ernie/configuration.py
+++ b/ernie/configuration.py
@@ -226,6 +226,7 @@ class Ernie4_5_Config(PretrainedConfig):
             * "attention_row_ln" - Attention row-wise layer normalization
             * "attention_column_ln" - Attention column-wise layer normalization
             * "mlp_column_ln" - MLP column-wise layer normalization
+            * "global" - Global configuration that applies to ALL operators
 
             - Value (`skip_num`): Controls how many times to skip recomputation:
             * 0: Never skip recomputation (minimum memory usage)

--- a/ernie/modeling_moe_pp.py
+++ b/ernie/modeling_moe_pp.py
@@ -210,10 +210,17 @@ def get_pp_vp_split_layers(config, skip_recompute_num=-1):
         return set(no_recompute_layer_num)
 
     if vp_size == 1:
-        # If vp_size == 1, we can not select model chunk for pp,
-        # so if skip_recompute_num > 0, we select the all layers to skip recompute.
+        # No virtual pipeline: skip last few layers of each physical stage
         if skip_recompute_num > 0:
-            return set(range(layer_num))
+            chunk_size = layer_num // pp_size
+            no_recompute_layers = []
+            for i in range(pp_size):
+                start = i * chunk_size
+                end = (i + 1) * chunk_size
+                # Skip last skip_recompute_num layers per physical stage
+                skip_start = max(start, end - skip_recompute_num)
+                no_recompute_layers.extend(range(skip_start, end))
+            return set(no_recompute_layers)
         else:
             return set()
 

--- a/ernie/modeling_moe_vl_pp.py
+++ b/ernie/modeling_moe_vl_pp.py
@@ -1027,6 +1027,7 @@ class ErnieDecoderLayerPipe(ErnieMoEDecoderLayer):
         if (
             self.config.recompute
             and self.config.recompute_granularity == "full"
+            and not self.config.skip_recompute_ops[self.layer_idx].get("global", False)
             and has_gradient
         ):
             decoderlayer_act_offload_settings = self.config.get(

--- a/erniekit/train/vl_sft/workflow.py
+++ b/erniekit/train/vl_sft/workflow.py
@@ -467,6 +467,7 @@ def run_vl_sft(
     cfg.use_attn_mask_start_row_indices = model_args.use_attn_mask_start_row_indices
     cfg.use_recompute_moe = model_args.use_recompute_moe
     cfg.recompute = finetuning_args.recompute
+    cfg.refined_recompute = finetuning_args.refined_recompute
     cfg.recompute_granularity = model_args.recompute_granularity
     cfg.use_recompute_loss_fn = model_args.use_recompute_loss_fn
     cfg.use_sparse_head_and_loss_fn = model_args.use_sparse_head_and_loss_fn

--- a/examples/configs/xpu/ERNIE-4.5-VL-28B-A3B/sft/run_sft_32k.yaml
+++ b/examples/configs/xpu/ERNIE-4.5-VL-28B-A3B/sft/run_sft_32k.yaml
@@ -86,9 +86,10 @@ sharding_parallel_config: "split_param enable_fuse_optimizer_states"
 sharding_comm_buffer_size_MB: 2048
 save_sharding_stage1_model_include_freeze_params: true
 offload_optim: true
-use_recompute_moe: true
+use_recompute_moe: false
 recompute: true
 recompute_granularity: full
+refined_recompute: "global:3"
 pre_alloc_memory: 60
 
 # amp

--- a/examples/configs/xpu/ERNIE-4.5-VL-28B-A3B/sft/run_sft_32k.yaml
+++ b/examples/configs/xpu/ERNIE-4.5-VL-28B-A3B/sft/run_sft_32k.yaml
@@ -85,7 +85,7 @@ sharding: "stage1"
 sharding_parallel_config: "split_param enable_fuse_optimizer_states"
 sharding_comm_buffer_size_MB: 2048
 save_sharding_stage1_model_include_freeze_params: true
-offload_optim: true
+offload_optim: false
 use_recompute_moe: false
 recompute: true
 recompute_granularity: full


### PR DESCRIPTION
* Add `global` param to `refined_recompute`
* Optimize ERNIE-4.5-VL SFT config for P800 96GB

`refined_recompute: "global:x"`的含义：n层`ErnieDecoderLayer`中有x层不重计算，n-x层重计算。默认所有层都会进行重计算。
n由模型结构确定，在4.5 VL中，`n=14`。P800上设置`global:3`时可以平衡显存和性能。