### PR TITLE
Add EB4.5 PT-Paddle bidirectional conversion tools

### DIFF
--- a/examples/pre-training/tools/cvt_eb45_paddle2pt.py
+++ b/examples/pre-training/tools/cvt_eb45_paddle2pt.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import paddle
+from safetensors import safe_open
+from safetensors.paddle import save_file
+from collections import defaultdict
+
+SRC_PATH = "./ERNIE-4.5-300B-A47B-Base-Paddle"
+DST_PATH = "./ERNIE-4.5-300B-A47B-Base-PT-out"
+
+os.makedirs(DST_PATH, exist_ok=True)
+
+with open(os.path.join(SRC_PATH, "model.safetensors.index.json")) as f:
+    src_map = json.load(f)["weight_map"]
+with open(os.path.join(SRC_PATH, "config.json")) as f:
+    config = json.load(f)
+
+assert (
+    config["hidden_size"] % config["num_attention_heads"] == 0
+), "head_dim not divisible"
+head_dim = config["hidden_size"] // config["num_attention_heads"]
+q_size = head_dim * config["num_attention_heads"]
+kv_size = head_dim * config["num_key_value_heads"]
+
+total_size = 0
+dst_map = {}
+
+src_rev_map = defaultdict(set)
+for k, v in src_map.items():
+    src_rev_map[v].add(k)
+
+for src_file, src_keys in src_rev_map.items():
+    print("reading:", src_file, "size:", len(src_keys))
+    dst_weight = {}
+
+    for src_key in sorted(src_keys):
+        with safe_open(
+            os.path.join(SRC_PATH, src_file), framework="paddle", device="cpu"
+        ) as f:
+            tensor = f.get_tensor(src_key)
+
+        base_key = src_key
+        if base_key.startswith("ernie."):
+            base_key = "model." + base_key[6:]
+
+        if ".up_gate_proj." in src_key:
+            # split gate_proj / up_proj (equal halves)
+            half = tensor.shape[-1] // 2
+            gate_tensor = tensor[:, :half]
+            up_tensor = tensor[:, half:]
+
+            # transpose back
+            gate_tensor = gate_tensor.T.contiguous()
+            up_tensor = up_tensor.T.contiguous()
+
+            gate_key = base_key.replace(".up_gate_proj.", ".gate_proj.")
+            up_key = base_key.replace(".up_gate_proj.", ".up_proj.")
+
+            dst_weight[gate_key] = gate_tensor
+            dst_weight[up_key] = up_tensor
+            dst_map[gate_key] = src_file
+            dst_map[up_key] = src_file
+
+        elif ".qkv_proj." in src_key:
+            # split q / k / v (unequal: q_size, kv_size, kv_size)
+            q_tensor, k_tensor, v_tensor = paddle.split(
+                tensor, [q_size, kv_size, kv_size], axis=-1
+            )
+
+            # transpose back
+            q_tensor = q_tensor.T.contiguous()
+            k_tensor = k_tensor.T.contiguous()
+            v_tensor = v_tensor.T.contiguous()
+
+            q_key = base_key.replace(".qkv_proj.", ".q_proj.")
+            k_key = base_key.replace(".qkv_proj.", ".k_proj.")
+            v_key = base_key.replace(".qkv_proj.", ".v_proj.")
+
+            dst_weight[q_key] = q_tensor
+            dst_weight[k_key] = k_tensor
+            dst_weight[v_key] = v_tensor
+            dst_map[q_key] = src_file
+            dst_map[k_key] = src_file
+            dst_map[v_key] = src_file
+
+        else:
+            # no merge, just possibly transpose
+            if "_proj." in src_key or ".gate." in src_key or "lm_head" in src_key:
+                tensor = tensor.T.contiguous()
+
+            dst_weight[base_key] = tensor
+            dst_map[base_key] = src_file
+
+        print(end=".", flush=True)
+
+    save_file(dst_weight, os.path.join(DST_PATH, src_file))
+    print()
+
+with open(os.path.join(DST_PATH, "model.safetensors.index.json"), "w") as f:
+    data = {
+        "metadata": {
+            "total_size": total_size,
+        },
+        "weight_map": dst_map,
+    }
+    json.dump(data, f, ensure_ascii=False, indent=2)
+print("done")

--- a/examples/pre-training/tools/cvt_eb45_pt2paddle.py
+++ b/examples/pre-training/tools/cvt_eb45_pt2paddle.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import paddle
+from safetensors import safe_open
+from safetensors.paddle import save_file
+from collections import defaultdict
+
+src_path = "./ERNIE-4.5-300B-A47B-Base-PT"
+dst_path = "./ERNIE-4.5-300B-A47B-Base-Paddle-out"
+
+os.makedirs(dst_path, exist_ok=True)
+
+with open(os.path.join(src_path, "model.safetensors.index.json")) as f:
+    src_map = json.load(f)["weight_map"]
+
+total_size = 0
+dst_map = {}
+
+src_rev_map = defaultdict(set)
+for k, v in src_map.items():
+    src_rev_map[v].add(k)
+
+for src_file, src_keys in src_rev_map.items():
+    print("reading:", src_file, "size:", len(src_keys))
+    dst_weight = {}
+
+    for src_key in src_keys:
+        if ".k_proj." in src_key or ".v_proj." in src_key or ".up_proj." in src_key:
+            continue
+
+        dst_key = src_key
+        if dst_key.startswith("model."):
+            dst_key = "ernie." + dst_key[6:]
+
+        key_decomp = [src_key]
+        if ".gate_proj." in src_key:
+            dst_key = dst_key.replace(".gate_proj.", ".up_gate_proj.")
+            key_decomp = [
+                src_key,
+                src_key.replace(".gate_proj.", ".up_proj."),
+            ]
+        elif ".q_proj." in src_key:
+            dst_key = dst_key.replace(".q_proj.", ".qkv_proj.")
+            key_decomp = [
+                src_key,
+                src_key.replace(".q_proj.", ".k_proj."),
+                src_key.replace(".q_proj.", ".v_proj."),
+            ]
+
+        weight_decomp = []
+        for key in key_decomp:
+            with safe_open(
+                os.path.join(src_path, src_file), framework="paddle", device="cpu"
+            ) as f:
+                tensor = f.get_tensor(key)
+            if "_proj." in key or ".gate." in key or "lm_head" in key:
+                tensor = tensor.T.contiguous()
+            weight_decomp.append(tensor)
+
+        dst_weight[dst_key] = (
+            weight_decomp[0]
+            if len(weight_decomp) == 1
+            else paddle.concat(weight_decomp, axis=-1)
+        )
+        dst_map[dst_key] = src_file
+        print(end=".", flush=True)
+
+    save_file(dst_weight, os.path.join(dst_path, src_file))
+    print()
+
+with open(os.path.join(dst_path, "model.safetensors.index.json"), "w") as f:
+    data = {
+        "metadata": {
+            "total_size": total_size,
+        },
+        "weight_map": dst_map,
+    }
+    json.dump(data, f, ensure_ascii=False, indent=2)
+print("done")


### PR DESCRIPTION
### 新增PT格式和Paddle格式权重互转的工具

使用方法：
1. 修改文件中的`src_path`和`dst_path`
2. 运行：
    ```bash
    python tools/cvt_eb45_pt2paddle.py
    python tools/cvt_eb45_paddle2pt.py
    ```

该工具只会生成 model-xxx.safetensors 和 model.safetensors.index.json，其他诸如 config.json、tokenizer.model 等不会生成，请自行从 [baidu/ERNIE-4.5-300B-A47B-Base-Paddle](https://huggingface.co/baidu/ERNIE-4.5-300B-A47B-Base-Paddle) 下载这些小文件并放到输出文件夹中